### PR TITLE
chore: bump nexus dep 1.5.3 → 1.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
 
     // Nexus DI + coroutines (local Maven)
-    implementation("net.badgersmc:nexus-core:1.5.3")
-    implementation("net.badgersmc:nexus-paper:1.5.3")
+    implementation("net.badgersmc:nexus-core:1.6.0")
+    implementation("net.badgersmc:nexus-paper:1.6.0")
 
     // Kotlin (downloaded at startup by LumaSGLoader)
     compileOnly(kotlin("stdlib"))


### PR DESCRIPTION
Nexus published version is 1.6.0 — pinning 1.5.3 breaks the VPS build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to enhance system stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BadgersMC/LumaSG/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->