### PR TITLE
docs(audit): LumaSG mass audit — 6 batch reports + triaged master report

### DIFF
--- a/docs/audit/COORDINATOR-SUMMARY.md
+++ b/docs/audit/COORDINATOR-SUMMARY.md
@@ -1,0 +1,58 @@
+# LumaSG Mass Audit — Coordinator Summary
+
+Generated: 2026-06-10
+Coordinator model: deepseek/deepseek-v4-flash
+Subagent model: minimax/minimax-m3
+Branch: `fix/audit-lumasg`
+
+## Per-batch finding counts by severity
+
+| Batch | crit | high | med | low | Total |
+|-------|------|------|-----|-----|-------|
+| audit-game | 4 | 4 | 7 | 11 | 26 |
+| audit-items | 0 | 5 | 7 | 3 | 15 |
+| audit-gui-commands | 2 | 4 | 8 | 7 | 21 |
+| audit-persistence | 0 | 5 | 11 | 9 | 25 |
+| audit-domain-util | 1 | 2 | 9 | 9 | 21 |
+| audit-hooks-misc | 0 | 3 | 6 | 10 | 19 |
+| **Total** | **7** | **23** | **48** | **49** | **127** |
+
+## Top 10 findings overall
+
+1. **[CRIT] audit-game — `PlayerStateManager.kt:61`** — `saveLocation=false` on world-change corrupts saved player location, causing incorrect respawn on death (server restart may strand players outside the arena).
+
+2. **[CRIT] audit-game — `Game.kt:164`** — `reconnectPlayer` overwrites the player's saved pre-game inventory with mid-game loot, enabling a rejoin dupe: die with inventory → disconnect → reconnect → pre-game inventory is now the death inventory, giving a second copy.
+
+3. **[CRIT] audit-game — `GameManager.kt`** — `killCommand`/`winCommand` template substitution uses raw string replacement with no escaping. An admin-customised command containing `{player}` in a player name or argument would inject arbitrary console commands.
+
+4. **[CRIT] audit-game — `TeamManager.kt:46`** + `TeamQueueManager.kt:82`** — Accepting a team invite does not remove the player from their previous team's `members` list, leaving the player simultaneously in two teams and enabling team-count exploits (e.g. 4+ players in a team-2 arena).
+
+5. **[CRIT] audit-domain-util — `Arena.kt` `scanForChests()`** — Cubic scan with default radius 500 iterates ~1.4 billion positions, blocking the Bukkit main thread for many minutes. Any player with setup permission can trigger this via `wand right-click`.
+
+6. **[HIGH] audit-gui-commands — `SGCommand.kt`** — `@Async` annotation on `SGCommand.create()` means Bukkit API calls (world loading, player teleportation, game state checks) run off the main thread, causing `IllegalStateException` under timing-sensitive conditions.
+
+7. **[HIGH] audit-gui-commands — `SGCommand.kt`** — `/sg forcestart` is a no-op: the `forceStart` path calls `arenaService.startGame()` but that method requires a `GamePlayer` list that is never built, so the game never actually begins.
+
+8. **[HIGH] audit-items — `ChestManager.kt`** — Double-chest refill only fills the first half (the block at the double-chest location), leaving the second chest half empty. Players learn which chests are "safe" and exploit the empty half.
+
+9. **[HIGH] audit-persistence — `PlayerStatsRepository.kt`** — K/D and Win-Rate leaderboards order by raw `kills`/`wins` columns instead of computing `kills / deaths` or `wins / games`. Players pad kills/stats to top the board without actually improving their ratio.
+
+10. **[HIGH] audit-hooks-misc — `PlayerDataCache.kt:74`** — On DB failure, `getCachedStats` returns and caches a zeroed `PlayerStats` with a 30-minute TTL. All downstream consumers (scoreboard, Discord embeds, leaderboards) show "Unknown Player" for half an hour. The DB outage is silently hidden.
+
+## detekt
+
+No detekt configuration file was found anywhere in the repository (`detekt*` / `.detekt*`). No static-analysis results to fold.
+
+## Cross-cutting items flagged by multiple batches
+
+- **Main-thread violations** — Appears across audit-game (`Game.kt`, `NameplateManager.kt`), audit-gui-commands (`SGCommand.kt`), audit-hooks-misc (`PlayerDataCache.kt`), and audit-domain-util (`InvitationManager.kt`). The project uses coroutines but several paths invoke Bukkit API off the main thread without `Bukkit.getScheduler().runTask()` or `ensureActiveOnMainThread()`.
+
+- **Game-phase / player-state desync** — audit-game (`eliminate()` for unknown UUIDs, `Team.isAlive` false on disconnect), audit-gui-commands (`CustomItemListener` damage bypasses phase rules), audit-items (`ChestManager` fills during active game). Multiple batches identify the same pattern: game-phase checks are missing or inconsistent across event listeners.
+
+- **Spectator inventory isolation** — audit-game (`reconnectPlayer` overwrites pre-game inventory) and audit-gui-commands (respawn spectator setup one tick late). The spectator inventory boundary is porous across reconnect and death paths.
+
+- **Silent error swallowing** — audit-persistence (`ArenaRepository` swallows JSON parse errors, returning zero locations), audit-domain-util (`InventorySerializer` fallback returns empty valid bytes), audit-hooks-misc (`PlayerDataCache` caches zeroed stats on DB failure). The codebase consistently hides failures from admins with no logging.
+
+- **Race conditions in caches** — audit-persistence (`CacheManager.getOrPut`, `StatisticsService.getOrCreate` have check-then-act races), audit-hooks-misc (`PlayerDataCache` Caffeine listener thread accesses Bukkit API). Demonstrated pattern of unsynchronised cache access across async boundaries.
+
+- **Test-coverage crisis** — With 29 test files for 85 main sources (~34% ratio), every batch reported severe coverage gaps. Names the most critical untested behaviors: game lifecycle (phase transitions, reconnect), chest refill concurrency, SQL migration correctness, player permission caching, and arena scan-for-chests performance.

--- a/docs/audit/MASS-AUDIT-2026-06-10.md
+++ b/docs/audit/MASS-AUDIT-2026-06-10.md
@@ -1,0 +1,203 @@
+# LumaSG Mass Audit — Consolidated Report (2026-06-10)
+
+Findings-only audit of all 86 main sources at commit `5baa40f`, run as one Hermes
+coordinator (DeepSeek v4 Flash) with 6 subagents (MiniMax M3), one per disjoint batch.
+Raw batch reports live alongside this file (`audit-*.md`, 127 raw findings). This
+document is the **operator-triaged** consolidation: every critical/high finding was
+manually verified against the source at `5baa40f`; severities were corrected and false
+positives removed. Medium/low findings are summarized by theme — see the batch reports
+for full detail.
+
+Triage stats: 30 crit/high raw findings verified line-by-line → 3 false positives,
+4 severity corrections. Verified false-positive rate ~15–20% (better than the 30–50%
+typical of earlier DeepSeek audits).
+
+---
+
+## Critical (verified)
+
+### C1. `game/Game.kt:164` — `reconnectPlayer` destroys the pre-game inventory snapshot
+`reconnectPlayer` calls `playerStateManager.saveAndPrepare(...)`, which **re-snapshots
+the player's current (mid-game) inventory** over the original pre-game snapshot taken on
+first join. When the game ends, `restore` returns the mid-game loot instead of the
+player's real items: the pre-game inventory is silently lost, and the player keeps a
+copy of game loot — a disconnect/reconnect dupe.
+**Fix direction:** on reconnect, skip the snapshot — teleport + re-prepare without
+overwriting `saved[uuid]`.
+
+### C2. `domain/Arena.kt:35-54` — `scanForChests()` freezes the main thread for minutes
+Triple-nested loop over `(2r+1)² × world height` block lookups, documented main-thread.
+With the default `radius = 500.0` that is ~385 million `getBlockAt` calls (Y is coerced
+to world bounds, so less than the raw cube, but still minutes of full server freeze).
+Reachable by anyone with setup permission via the wand/scan flow.
+**Fix direction:** chunk-bounded async scan with a radius sanity cap.
+
+### C3. `gui/GameBrowserMenu.kt:65-77` — players can join games in Active/Deathmatch
+The click handler checks only "already in game" and the size cap — never `game.phase` —
+and `Game.addPlayer` (Game.kt:105) has no phase guard either. A player can join a live
+match at a fresh spawn with full health, including re-entry by eliminated spectators.
+**Fix direction:** phase gate in `Game.addPlayer` itself (defence in depth) plus
+greyed-out browser buttons. Same handler also has a TOCTOU on `maxPlayers` (size check
+then `addPlayer`, no capacity check inside `addPlayer`).
+
+---
+
+## High (verified)
+
+### H1. `game/PlayerStateManager.kt:61` — `saveLocation=false` saves the arena spawn as "restore location"
+The saved location becomes the arena spawn the player was just teleported to, so restore
+returns players to the arena instead of where they came from (or strands them if the
+world unloads). Make the saved location nullable and treat null as "use lobby".
+
+### H2. `game/Team.kt:19-21` — `Team.isAlive` is online-status, not elimination-status
+A team whose members all briefly disconnect is instantly "dead" to
+`checkWinCondition` — a lag spike or deliberate relog can hand the win to the
+opposing team. `isAlive` should derive from `isEliminated`/alive-player tracking, not
+`Bukkit.getPlayer(...)?.isOnline`.
+
+### H3. `commands/SGCommand.kt:296-319` — `/sg forcestart` is a no-op
+Validates arena/game/phase/players, then only sends "Force-started" — no code path
+advances the phase or skips the countdown. (Related: `Game.skipGracePeriod()` at
+Game.kt:445 is an empty stub.)
+
+### H4. `commands/SGCommand.kt:437-464` — `@Async create` touches Bukkit API off the main thread
+Reads `player.location` and calls `player.sendMessage` from the async dispatcher. Drop
+`@Async` or wrap Bukkit access in `withContext(bukkitDispatcher)`.
+
+### H5. `game/TeamQueueManager.kt:76-90` — accepting an invite doesn't leave the previous team
+`accept` adds the player to the new pre-game team and overwrites the pointer while the
+old team's `members` list still contains them — one player in two teams, breaking team
+size and win-condition counts. (Note: the in-game `TeamManager.acceptInvite` is
+**correct** — it calls `removeFromTeam` first. Only the queue path is broken.)
+
+### H6. `game/Game.kt:138-151` — `eliminate(uuid)` mutates state for unknown UUIDs
+No membership precondition: a stale/double call pushes ghost entries into
+`eliminationOrder` and `spectators` and can remove a real player from a team. Add an
+early return when `_players[uuid] == null` and make eliminate idempotent.
+
+### H7. `persistence/repositories/PlayerStatsRepository.kt:64-65` — K/D and Win-Rate leaderboards are fake
+`KILL_DEATH_RATIO` orders by raw `kills`, `WIN_RATE` by raw `wins`. 100k/100d ranks
+above 50k/1d. Compute the ratio in SQL (`CAST(kills AS DOUBLE)/NULLIF(deaths,0)`).
+
+### H8. `util/cache/PlayerDataCache.kt` — three related cache bugs
+- `:192-197` — DB failure returns and caches a **zeroed `PlayerStats`** ("Unknown
+  Player") for up to 30 min; scoreboards/placeholders/Discord show a stats reset while
+  the outage is hidden.
+- `:199-208` — `loadPermissionFromBukkit` runs `getPlayer`/`hasPermission` on a Caffeine
+  worker thread; on Paper the exception is swallowed and **`false` is cached for 10
+  min** — an admin silently loses permissions.
+- `:101-115` — `getCachedDisplayName` calls `Bukkit.getPlayer` on `supplyAsync`'s
+  executor, same main-thread violation.
+
+### H9. `items/AirstrikeItem.kt:293-298` — friendly-fire immunity is inverted
+The caller's team is added to the immune set, then the **caller is removed** — teammates
+are immune, the caller takes their own meteor damage. Delete the `remove(callerUuid)`
+line (or document the intended policy).
+
+### H10. `items/AirstrikeItem.kt:183-189` — item consumed before the game lookup
+`held.amount--` runs before `getGameForPlayer(uuid) ?: return` — if the game resolution
+fails (player left/game ended in the same tick), the airstrike is consumed with no
+strike. Resolve the game first, then consume.
+
+### H11. `items/CustomItemsManager.kt:99-104` — `reload()` double-registers listeners
+`shutdownItems()` doesn't `HandlerList.unregisterAll`; `registerDefaults()` re-calls
+`item.register()` → duplicate event handling and doubled periodic tasks after every
+`/sg reload`.
+
+### H12. `listeners/AdminWandListener.kt:88-99` — wand edits persist only via the shutdown flush
+Spawn/center edits go through `arenaService.addToCache` (memory only). They ARE flushed
+by `onDisable → saveAll()` on clean shutdown, but a crash, kill, or `/sg admin reload`
+before shutdown loses all wand work. (Downgraded from the batch report's critical; the
+shutdown flush exists.) The new sneak-right-click removal path has the same gap.
+**Fix direction:** persist on each edit (suspend `saveArena`) or a periodic flush.
+
+### H13. `listeners/ChestListener.kt:57-115` — cross-arena chest fill when arenas share a world
+Chunk-load fill resolves "the game in this world" as the *first* match — with two active
+arenas in one world, arena B's chests fill with arena A's loot tier, and `filledChests`
+tracking is shared. Scope fills to arena bounds.
+
+### H14. `listeners/CustomItemListener.kt:75-217` — bomb/poison/fire damage bypasses phase & friendly-fire rules
+Direct `target.damage(...)` + velocity, filtered only by thrower — works on teammates
+with `friendlyFire=false` and during Waiting/Countdown/Grace. Enforce the same gates
+`PlayerListener.onEntityDamage` applies.
+
+### H15. `items/AirdropFlareItem.kt:99-108` — airdrop chest placed with no safety checks
+Chest placed at the player's *current* (post-explosion) position, silently overwriting
+any block (signs, chests with contents), possibly inside the player or floating at y=1.
+Snapshot the target at use time; verify air + arena bounds before placing.
+
+### H16. `listeners/PlayerListener.kt:121-125` (+ win/celebration paths) — console command injection via name substitution
+`killCommand`/`winCommand` templates substitute `<player>` raw into a console dispatch.
+Vanilla names are charset-limited, but Floodgate/Geyser (and display-name refactors)
+allow spaces — argument injection into a console-privileged command. (Downgraded from
+critical: separator injection (`;`) doesn't apply to Bukkit dispatch; argument injection
+does.) Validate the substituted name or restrict substitution to a single token.
+
+---
+
+## Medium — dominant themes (see batch reports for the full list of 48)
+
+- **Check-then-act races in caches** — `CacheManager.getOrPut`,
+  `StatisticsService.getOrCreate` (duplicate DB work under burst; the batch report's
+  "duplicate rows" claim is wrong — the `(uuid, lootMode)` PK upsert can't duplicate —
+  but redundant queries and a lost `playerName` on race are real),
+  `LootTableCache.getPreGeneratedChest` double-generation,
+  `InvitationManager.createInvitation`.
+- **Silent error swallowing** — `ArenaRepository` coerces bad JSON to empty
+  spawn/chest lists with no log (arena silently breaks);
+  `InventorySerializer.serializeInventory` falls back to a *valid empty payload* on
+  failure (player inventories silently wiped on restore); `UUID.fromString` on stored
+  columns can kill whole queries; `ArenaRepository` rotates a corrupt arena `id` to a
+  random UUID on every load.
+- **Main-thread violations off the happy path** — fire-and-forget
+  `NameplateManager.stop()` racing scope cancellation; `MeteorUtils` helpers with no
+  thread contract; `ConcurrentChestFiller` error-path `chest.location` access;
+  `DiscordService.awaitReady()` blocking `onEnable`.
+- **Shutdown/migration robustness** — `DatabaseService` legacy migration has no
+  `try/finally` around `PRAGMA foreign_keys = OFF` (a failed rebuild leaves FK
+  enforcement off on a pooled connection); `WorldManager.cleanup()` restores a 60M
+  default border if `setup()` early-returned; `ArenaService.removeArena` is cache-first
+  (DB failure resurrects the arena on restart).
+- **Stats integrity** — ragequit overwrites `bestPlacement` with `totalPlayers`;
+  `getTotalPlayerCount` counts (uuid, mode) rows (3× actual);
+  `getAggregatedStats` returns a fake `lootMode=MODERN` record that would corrupt the
+  MODERN row if ever passed back to `upsert`; per-kill stats are 2 DB round-trips each
+  on a 1-connection SQLite pool.
+
+## Low
+
+49 findings — style, dead code (`removePlayer(teleportToLobby,…)` partially dead,
+`gameTime` unused, `skipGracePeriod` stub), unclosed `URLConnection` stream in
+`Celebration`, plaintext Discord token in config, unregistered hooks on reload, cooldown
+granularity, hardcoded radii. See the batch reports.
+
+---
+
+## False positives removed during triage
+
+| Batch claim | Why it's wrong |
+|---|---|
+| `TeamManager.kt:46` — acceptInvite leaves player in two teams (crit) | `acceptInvite` calls `removeFromTeam(invitee)` at line 50 **before** `team.add`. Correct as written. (The `TeamQueueManager` half of the finding is real → H5.) |
+| `ChestManager.kt:154` — double chests only half-filled (high) | `org.bukkit.block.Chest.getInventory()` returns the merged `DoubleChestInventory` for double chests — clear + fill operate on all 54 slots. (Residual nit: `ChestListener` keys `filledChests` per half, so a double chest can be cleared/refilled twice on chunk load.) |
+| `StatisticsService.kt:23` — concurrent `getOrCreate` creates duplicate PK rows (high) | `upsert` on PK `(uuid, lootMode)` updates on conflict; duplication is impossible. Race wastes queries and can clobber `playerName` → downgraded to medium. |
+| `Game.kt:181` — `removePlayer(Player,…)` "uses neither parameter" (low) | `restoreState` **is** used (line 185); only `teleportToLobby` is dead. |
+
+## Test coverage
+
+29 test files vs 86 main sources, concentrated in persistence/domain. Zero coverage of:
+game lifecycle (reconnect, eliminate, win condition), all listeners, all GUIs, all 11
+custom items, chest filling, and every cache. Each batch report ends with a prioritized
+test list; the highest-value five:
+
+1. `reconnectPlayer` preserves the pre-game snapshot (catches C1).
+2. `GameBrowserMenu`/`Game.addPlayer` rejects joins outside Waiting/Countdown (C3).
+3. `Team.isAlive` with all members offline but not eliminated (H2).
+4. KDR/Win-Rate leaderboard ordering with adversarial stat rows (H7).
+5. `CustomItemsManager.reload()` does not duplicate listener registration (H11).
+
+## Run metadata
+
+- Audited revision: `5baa40f` (origin/main, 2026-06-10)
+- Coordinator: `deepseek/deepseek-v4-flash` · Subagents: `minimax/minimax-m3`
+- Branch: `fix/audit-lumasg` on the Hermes fork; no source files modified
+- Operator triage: Claude (Fable 5), all crit/high verified against source

--- a/docs/audit/MASS-AUDIT-PLAN.md
+++ b/docs/audit/MASS-AUDIT-PLAN.md
@@ -1,0 +1,94 @@
+# LumaSG Mass Audit — Methodology & Batch Plan
+
+Findings-only audit driven by ONE Hermes coordinator running **DeepSeek v4 Flash**
+(`deepseek/deepseek-v4-flash`, 1M ctx) with **6 subagents**, one per batch below.
+**No source files are modified.** Each subagent audits one disjoint batch and writes a
+single report at `docs/audit/<batch>.md`. The coordinator commits all six reports plus a
+brief `docs/audit/COORDINATOR-SUMMARY.md` (counts per severity per batch), then pushes
+branch `fix/audit-lumasg` to the `fork` remote. The operator (Claude, locally) fetches
+the branch, triages false positives, and synthesizes a consolidated master report for one
+docs-PR to `BadgersMC/LumaSG`.
+
+Repo facts: 86 main Kotlin files under `src/main/kotlin/net/lumalyte/lumasg/`, 29 test files.
+
+## What every subagent hunts for (priority order)
+
+1. **Correctness** — null/async misuse, Bukkit main-thread violations (world/entity access
+   off-thread), race conditions in game state transitions, wrong edge cases, broken
+   invariants, resource leaks (unclosed `Statement`/`ResultSet`/`Connection`/streams).
+2. **Security** — SQL injection (string-concatenated queries vs parameterized), unsafe
+   deserialization (item NBT/serialized stacks), permission/command bypass, secret leakage
+   (Discord tokens/webhooks), path traversal in config or arena file handling.
+3. **Game-integrity** — duplication exploits (chest refill, death drops, spectator
+   inventory), reward/statistics manipulation, state desync between game phase and player
+   state.
+4. **Test-coverage gaps** — name the specific untested behavior and the test that should
+   exist (only 29 test files vs 86 main).
+
+The coordinator also runs `detekt` once for free quality signal and folds real hits into
+the relevant batch report.
+
+## Severity rubric
+
+| Sev | Meaning |
+|-----|---------|
+| crit | Exploitable security hole or data-loss/corruption bug reachable in normal use |
+| high | Logic bug that breaks a feature, or an exploit a player can trigger in-game |
+| med  | Edge-case bug, resource leak under load, missing test for important logic |
+| low  | Style/quality, defensive-coding nit, minor untested branch |
+
+Report format, one section per finding:
+
+```
+### [SEV: crit|high|med|low] <relative/path>.kt:<line> — <one-line title>
+**What:** <the problem, concretely>
+**Why it matters:** <impact / exploit / failure mode>
+**Suggested fix:** <direction, not full code>
+**Confidence:** high | med | low
+```
+
+## Batches (disjoint file sets, 86 files, 6 subagents)
+
+All packages relative to `src/main/kotlin/net/lumalyte/lumasg/`.
+
+| # | Batch (report file) | Packages | Files |
+|---|---------------------|----------|-------|
+| 1 | `audit-game` | `game/**` | 16 |
+| 2 | `audit-items` | `items/**`, `chest/**` | 13 |
+| 3 | `audit-gui-commands` | `gui/**`, `commands/**`, `listeners/**` | 14 |
+| 4 | `audit-persistence` | `persistence/**`, `statistics/**`, `config/**`, `service/**` | 11 |
+| 5 | `audit-domain-util` | `domain/**`, `permissions/**`, `util/` (non-cache) | 17 |
+| 6 | `audit-hooks-misc` | `hooks/**`, `discord/**`, `debug/**`, `util/cache/**`, root files | 15 |
+
+Batch 4 carries the SQL-injection focus; batches 1–2 carry the dupe-exploit focus;
+batch 6 carries the secret-leakage focus (Discord integration).
+
+Each subagent receives its exact file list (the coordinator enumerates the package globs
+at runtime with `git ls-files`) and writes ONLY its own `docs/audit/<batch>.md`. Subagents
+share the read-only working tree — disjoint output files mean no collisions.
+
+## Operator workflow (single dispatch)
+
+1. **Prereqs (one-time):**
+   - Clone `BadgersMC/LumaSG` to `/opt/data/LumaSG` in the Hermes container.
+   - Create fork `Hermes-Enthusia/LumaSG` on GitHub; add it as the `fork` remote on the
+     box (push-auth via the Hermes PAT). Verify `git push fork` works and
+     `git push origin` 403s.
+   - Push this plan doc to BadgersMC origin on branch `docs/audit-plan`
+     (`dispatch.sh` reads it via `git show origin/docs/audit-plan:docs/audit/MASS-AUDIT-PLAN.md`).
+2. `HERMES_REPO=/opt/data/LumaSG dispatch.sh --job audit-lumasg --docs-branch docs/audit-plan
+   --plan-path docs/audit/MASS-AUDIT-PLAN.md --prompt /tmp/audit-lumasg.txt
+   --model deepseek/deepseek-v4-flash` (branch on box becomes `fix/audit-lumasg`).
+3. `poll.sh --job audit-lumasg` — done when `fix/audit-lumasg` appears on the fork.
+4. Locally: `git fetch hermes refs/heads/fix/audit-lumasg:refs/heads/hermes-audit`,
+   read all six `docs/audit/*.md`.
+5. Triage (expect 30–50% false positives from DeepSeek, especially "SQL injection" claims
+   on parameterized queries), dedupe, rank → `docs/audit/MASS-AUDIT-<date>.md`, one PR.
+
+## Coordinator rules (baked into the dispatch prompt)
+
+- Findings-only: NEVER modify any file outside `docs/audit/`.
+- Spawn 6 subagents, one per batch; each writes only its own report file.
+- No gradle build gate (nothing to compile-verify) — but DO run detekt once.
+- Push to the `fork` remote ONLY. Finish by printing `AUDIT-LUMASG_DONE` plus per-batch
+  finding counts; print `AUDIT-LUMASG_HALT` with the error if blocked 3 times.

--- a/docs/audit/audit-domain-util.md
+++ b/docs/audit/audit-domain-util.md
@@ -1,0 +1,309 @@
+# Audit Report: audit-domain-util
+
+Scope: 17 files under `domain/`, `permissions/`, and `util/` (non-cache) of the LumaSG plugin. Findings grouped by severity. No source files were modified.
+
+---
+
+### [SEV: crit] src/main/kotlin/net/lumalyte/lumasg/domain/Arena.kt:35-54 — `scanForChests()` cubic scan will freeze the main thread
+
+**What:** `scanForChests()` performs a triple-nested loop over the full cubic volume `(2*radius+1)^3` with no chunk loading, no async batching, and no budget. With the default `radius = 500.0` (line 18), the loop is 1001 × ~1384 × 1001 ≈ 1.39 billion iterations, each calling `world.getBlockAt(x, y, z)`. Even with cheap block lookups the wall time is in the many-minutes range; with cache misses it is effectively a server hang.
+
+**Why it matters:** This is documented to be called on the main thread (line 33). When triggered from `/lumasg ...` setup, `onEnable()`, or any UI/command handler, the entire server tick loop stops. Every player on the server freezes. This is reachable in normal use by any player with `lumasg.setup.games` invoking the command that drives it. Tied-for-most-impactful bug in this batch.
+
+**Suggested fix:** Replace with a chunk-bounded scan (`world.getChunkAt(cx >> 4, cz >> 4)`) and either load the relevant chunks first, or stream a `MapIterator` per chunk. Long-term: do this off the main thread via a coroutine and progressively update `chestLocations`. Also add a sanity cap (e.g., refuse radius > 50) and warn if `radius.toInt()^3 > 10_000_000`.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] src/main/kotlin/net/lumalyte/lumasg/util/InventorySerializer.kt:43-55 — Silent data loss in `serializeInventory` fallback
+
+**What:** When `ItemStack.serializeItemsAsBytes(items.toList())` throws, the catch block (line 46) re-serializes an *empty* inventory of the same `items.size` and returns that as a valid `ByteArray`. Callers cannot distinguish "real serialization of these items" from "fallback empty array."
+
+**Why it matters:** If this is used to persist a player's loot/inventory contents (death drops, disconnect save, pre-game loadout, etc.), a one-time serialization failure silently wipes the player's items. The error is logged but the data is gone. Reachable in normal use any time the serializer throws (e.g., exotic NBT from a third-party plugin, OOM, classloader issues).
+
+**Suggested fix:** On fallback, return `null` and log loudly, OR introduce a sentinel (e.g., a wrapper that carries "this is empty fallback"). Better: make the failure path explicit and let the caller decide whether to retry / block the event / etc. Do not invent a "successful" empty payload.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] src/main/kotlin/net/lumalyte/lumasg/domain/Arena.kt:36-37 — `scanForChests()` returns empty list silently on unloaded / missing world
+
+**What:** `Bukkit.getWorld(worldName) ?: return emptyList()` and `center.toBukkit() ?: return emptyList()` both silently return `emptyList()` if the world is not loaded or the `SerializableLocation` cannot be resolved. The function name implies it scans the arena; in practice, the user gets an empty result with no log, no warning, no exception.
+
+**Why it matters:** A setup admin runs the chest-scan command on an arena whose world is currently unloaded (server restart, world not yet loaded, world name typo). The arena is then saved with zero chest locations, breaking chest-refill loot logic (see GameIntegrity concern in the audit methodology) and the looted item economy. There is no signal to the admin that anything went wrong.
+
+**Suggested fix:** Log a `WARN` with the world name and a hint ("is it loaded?") and either return a sentinel like `Result<List<SerializableLocation>>` or surface the failure to the calling command so the admin sees an error. Consider also `world.loadChunksFor(center, radius)` semantics (or a chunk-preload step) before scanning.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/InvitationManager.kt:29-35 — `removalListener` does not clean up `playerActiveInvitations` on TTL/size eviction
+
+**What:** When Caffeine evicts an entry due to TTL expiry (30s) or size (1000), the `removalListener` only logs the eviction. The corresponding entry in `playerActiveInvitations: ConcurrentHashMap<UUID, String>` is left dangling — the invitee's UUID still points to a key that no longer exists in the cache.
+
+**Why it matters:** The map grows monotonically up to the number of distinct invitees who ever received an invitation that wasn't explicitly `accept`/`decline`/`removePlayerInvitations`-d. Cleanup only happens opportunistically inside `getPlayerInvitation` (line 79), so a player who receives and ignores an invitation keeps a stale mapping forever. Under a busy server, the map leaks UUID→String entries for the lifetime of the plugin.
+
+**Suggested fix:** Move cleanup into the removal listener: capture the `invitation.invitee` and call `playerActiveInvitations.remove(invitation.invitee, key)`. This also needs to be safe under concurrent createInvitation calls — the listener should not yank a *new* mapping that has the same invitee UUID. Use the `remove(key, value)` form of ConcurrentHashMap to compare-and-remove.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/InvitationManager.kt:46-63 — `createInvitation` race loses the new invitation's mapping
+
+**What:** Lines 50-56 do `get existing key → invalidate existing → put new → put mapping`. The first three operations on `playerActiveInvitations` and `invitationsCache` are not atomic. If two threads call `createInvitation` for the same `invitee` concurrently (e.g., command handler and async event listener), one thread can:
+1. read existingKey = null
+2. thread B reads existingKey = null
+3. A puts A into cache, sets mapping to A
+4. B puts B into cache, overwrites mapping to B
+5. Caffeine's removalListener fires for A and could even yank the invitee's mapping back to null if the listener is added
+
+Net effect: B is in the cache, B's mapping is set. A is in the cache (TTL'd 30s) but is unreachable. Acceptable, but the 30s window where A is a "ghost" invitation isn't a leak — it expires — yet the *primary* correctness issue is that the *opposite* interleaving can drop B's mapping if the removalListener is added (line 30-34) and cleans up via `playerActiveInvitations.remove(invitation.invitee)` without comparing values.
+
+**Why it matters:** Subtle. In a single-threaded Bukkit command context it's fine. In a coroutine context, the cache listener could in principle be invoked concurrently with the map write, causing the mapping to be wiped for an unrelated newer invitation. Currently the listener only logs (doesn't remove), so the worst case is an unreachable ghost entry — but adding cleanup to the listener (as suggested in the previous finding) makes this race a *correctness* bug unless guarded with compare-and-remove.
+
+**Suggested fix:** When adding cleanup to the removal listener, use `playerActiveInvitations.remove(invitee, key)` so the listener only clears the mapping if it still points to the *evicted* key. Optionally: synchronize `createInvitation` per-invitee with a striped lock keyed by `invitee.hashCode()`.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/InvitationManager.kt:173-177 — `Bukkit.getPlayer` called from potentially off-main-thread coroutine context
+
+**What:** `getPlayerName(playerId)` calls `Bukkit.getPlayer(playerId)?.name`. This is documented to be called from inside the removalListener (Caffeine invokes listeners on the thread that triggered the operation) and from logging inside `createInvitation`. Caffeine can call its removalListener from any thread that touches the cache, including async coroutine dispatchers.
+
+**Why it matters:** `Bukkit.getPlayer(UUID)` is not thread-safe in all Paper versions; even where it doesn't throw, results can be inconsistent with the main thread's view of online players. More directly, this is a Bukkit main-thread contract violation if the cache is ever read off-thread.
+
+**Suggested fix:** Either: (a) only call `Bukkit.getPlayer` from the main thread (wrap in `Bukkit.getScheduler().callSyncMethod` or use a `BukkitDispatcher`); or (b) cache the name snapshot at invitation creation time and store it on `TeamInvitation` so the listener doesn't need to look it up. The latter is cleaner and removes a Bukkit call from the hot path.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/MeteorUtils.kt:21-247 — All spawn helpers touch Bukkit world/entities without a thread-safety contract
+
+**What:** `spawnMeteorSphere`, `spawnPhysicsExplosion`, `spawnShockwaveRing`, `spawnGroundCircle`, `spawnVisualDebris`, and `spawnExplosion` all call `world.spawnParticle`, `world.getBlockAt`, `world.spawnFallingBlock`, `world.playSound`, `world.getNearbyEntities`, and modify `FallingBlock` entities. None of these helpers are documented as main-thread-only, and `spawnVisualDebris` even mutates `FallingBlock.dropItem`, `setHurtEntities`, and `velocity` (lines 183-195) — all main-thread-only Bukkit operations.
+
+**Why it matters:** If a caller invokes these from a coroutine dispatcher other than `BukkitDispatcher`, the Paper scheduler will throw `IllegalStateException` or, worse, race with the main thread and produce inconsistent state (e.g., `FallingBlock` set up with `dropItem = true` after a server tick boundary). The `launchMeteor` coroutine (line 249) does use `withContext(bukkitDispatcher)` per-tick, but it invokes `spawnMeteorSphere` from inside that block — which is fine, but the helper itself can be misused.
+
+**Suggested fix:** Either annotate the helpers' docstrings with `@MainThread` / `// Must be called on the main thread`, or accept a `BukkitDispatcher` and `withContext` internally. Also: in `spawnVisualDebris` the spawned `FallingBlock` entities are never cleaned up — they remain in the world until they hit a block, the void, or despawn. Add a delayed despawn task or use `setTicksLived`.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/MeteorUtils.kt:264-273 — `launchMeteor` divides by `totalDistance` without a guard
+
+**What:** Line 260 sets `val totalDistance = meteorStart.distance(target)`. Line 267 computes `val progress = (1.0 - (distanceToTarget / totalDistance)).coerceIn(0.0, 1.0)`. If a caller passes a `target` equal to (or extremely close to) the computed `meteorStart`, `totalDistance` is 0 and the division yields NaN, which propagates through `currentSpeed`, `arcHeight`, and `direction`, leaving the meteor spinning in place until the 2000-tick cap.
+
+**Why it matters:** Edge case, but reachable if a caller computes the meteor start from the target and forgets to add an offset, or if `horizontalOffset = 0` and `spawnHeight = 0` are passed. The `if (distanceToTarget < 3 || currentLocation.y <= target.y) break` guard on line 283 will eventually exit, but only after up to 100 seconds of bogus particle work.
+
+**Suggested fix:** If `totalDistance < 1.0`, skip the loop and immediately `onImpact()`. Or add a precondition `require(spawnHeight > 0 && horizontalOffset > 0)`.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/ErrorHandlingUtils.kt:289-340 — `CircuitBreaker` fields are not thread-safe
+
+**What:** `failureCount: Int`, `isOpen: Boolean`, and `lastFailureTime: Long` are plain `var ... private set` properties (lines 289-295). `isOpen` and `failureCount` are read and written across the success and failure paths of `execute(...)` (lines 304-339) without `volatile` / `AtomicInteger` / `AtomicBoolean` semantics.
+
+**Why it matters:** If a single `CircuitBreaker` instance is shared across coroutines or threads (which the lack of a "single-threaded only" contract invites), updates to `failureCount` from one thread are not guaranteed to be visible to another. The circuit may stay open (or stay closed) indefinitely; or `failureCount >= failureThreshold` may not be observed promptly. This is a resource-stability / observability bug under load, not a data-corruption bug.
+
+**Suggested fix:** Make the three fields `@Volatile` and use `AtomicInteger` for `failureCount` with a compare-and-set on threshold-crossing. Or document "single-thread use only" and require callers to wrap with their own synchronization.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/InventorySerializer.kt:122-136 — `calculateSize` divides by `items.size` without a zero check
+
+**What:** `"%.1f".format(base64Data.size.toDouble() / items.size)` on line 132. If `items.size == 0` and the empty array still serializes successfully (it does — see the `emptyItems` fallback), this evaluates to `0.0 / 0.0 = NaN` and the formatted string becomes `"NaN bytes"`.
+
+**Why it matters:** Cosmetic / defensive-coding nit on the surface, but the surrounding code (line 36-56) returns a non-null `ByteArray` for empty inventories, so `calculateSize(arrayOf())` is a real call path. Returns a misleading string to whoever invokes it. Easy to fix.
+
+**Suggested fix:** Early-return when `items.isEmpty()`. Better, document that `calculateSize` requires a non-empty array.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/domain/StatType.kt:8-9 — `columnName` for KDR and WinRate is semantically wrong
+
+**What:** `KILL_DEATH_RATIO("K/D Ratio", "kills")` and `WIN_RATE("Win Rate", "wins")` reuse the base columns. The enum's contract (per the class docstring "Types of statistics that can be used for leaderboard filtering") implies `columnName` is the column the leaderboard SQL will `ORDER BY`. Ordering by raw `kills` for KDR and raw `wins` for WinRate is wrong — a 100-kill / 100-death player ranks above a 10-kill / 1-death player on KDR, and a 100-win / 1000-game player ranks above a 10-win / 10-game player on WinRate.
+
+**Why it matters:** Depends on whether the leaderboard code uses this column name blindly. If the SQL builder does `"ORDER BY $columnName DESC"`, every leaderboard using KDR or WinRate produces wrong rankings — a player-integrity bug that can be triggered by any player opening the leaderboard GUI. This is the most-likely-to-be-exploited bug in this file: an op player can pad `kills` to top the KDR leaderboard without actually being the best K/D.
+
+**Suggested fix:** Either: (a) make the leaderboard SQL smart enough to compute KDR/WinRate inline and order by the computed expression, ignoring `columnName` for these cases; or (b) replace `columnName` with a sealed-class hierarchy that distinguishes "raw column" vs "computed expression" cases. Verify the actual leaderboard consumer and patch both ends.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] src/main/kotlin/net/lumalyte/lumasg/util/ItemUtils.kt:195,180 — Enchantments added with `ignoreLevelRestriction = true`
+
+**What:** `meta.addEnchant(enchant, level, true)` (line 195) and `meta.addStoredEnchant(enchant, level, true)` (line 180) both pass `true` for `ignoreLevelRestriction`. This means a config-driven item can be Sharpness X, Protection X, Fortune X, etc. — beyond vanilla max levels.
+
+**Why it matters:** Items are loaded from YAML config files on the server; only trusted admins can edit them, so this is *not* a player-exploitable bug. However: (a) if any config gets committed to a public repo, a malicious fork can hand out overpowered custom items; (b) the items can break vanilla combat balance assumptions; (c) other plugins that read item levels (e.g., anti-cheat, scoreboards) may not handle >vanilla levels. The current behavior silently overrides the safety net Bukkit provides.
+
+**Suggested fix:** Read the enchantment's max level from the registry and clamp the configured level. Or add a config flag `over-level-enchantments: true` per item that explicitly opts in.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/domain/PlayerStats.kt:27 — `kdr` is unbounded when `deaths == 0`
+
+**What:** `if (deaths == 0) kills.toDouble() else kills.toDouble() / deaths` — a player with 1000 kills and 0 deaths reports KDR = 1000.0, which dominates the leaderboard.
+
+**Why it matters:** Cosmetic concern, but combined with the `StatType` finding above it amplifies the ranking issue. The conventional normalization is `kills / (deaths + 1)` or `kills / max(1, deaths)`.
+
+**Suggested fix:** Use the conventional formula or cap at, say, 100.0. Document the chosen convention.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/domain/GamePhase.kt:8-12 — `Countdown`, `Grace`, `Active`, `Deathmatch`, `Ended` are immutable, complicating in-place phase mutation
+
+**What:** All `GamePhase` subclasses use `val` for their state (`secondsLeft`, `secondsRemaining`, `winner`). Updating a tick counter therefore requires `currentPhase = currentPhase.copy(secondsLeft = currentPhase.secondsLeft - 1)`, which is a new object each tick.
+
+**Why it matters:** Not a bug, but it forces a `var GamePhase` holder somewhere, and the holder is now a race-condition magnet. For a sealed-class state machine, the safer idiom is a separate `GameState` holder class with a synchronized tick method. Worth a code-smell flag.
+
+**Suggested fix:** Keep the sealed types but introduce a `GameState` wrapper that owns the mutable secondsRemaining internally and exposes a `phase: GamePhase` derived value. Or accept the allocation cost (it's a single object per tick — fine) but document the holder as single-threaded.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/domain/ArenaTemplate.kt:19-25 — `applyTo` silently ignores several arena fields
+
+**What:** `applyTo` only copies `displayName`, `minPlayers`, `maxPlayers`, `radius`, and `allowedBlocks` into the new arena. It does not touch `name`, `worldName`, `spawnPoints`, `center`, `chestLocations`, `lobbySpawn`, `spectatorSpawn`, or `enabled`. The docstring says "Apply this template's settings to an existing arena" but the unmentioned fields are quietly preserved.
+
+**Why it matters:** A future maintainer who adds `description` to `ArenaTemplate` and assumes it cascades will be surprised. Also, if the template's intent is to *fully* define the arena, half-applying is more confusing than a full copy or a documented partial merge.
+
+**Suggested fix:** Either (a) document explicitly which fields are template-controlled, or (b) make `applyTo` exhaustive and validate required fields per template.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/util/MiniMessageUtils.kt:143-166 — `convertLegacyToMiniMessage` is case-sensitive and lossy
+
+**What:** The chain of `.replace("&a", "<green>")` etc. only matches lowercase Minecraft legacy codes. Real legacy `&A` is not handled. Additionally, the `&` character is never escaped, so a player who *meant* to type a literal `&c` in chat (rare, but possible in lore text) will have it silently replaced with `<red>`.
+
+**Why it matters:** Cosmetic / defensive-coding. Not security (no template injection — these are simple string replaces, not MiniMessage parsing at this stage).
+
+**Suggested fix:** Pre-lowercase the string for the replacements, or expand the table with uppercase variants. For literal `&` survival, offer an opt-in escape.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/util/MiniMessageUtils.kt:176-182 — `processPlaceholders` iteration order is non-deterministic
+
+**What:** Iterates over a `Map<String, String>` whose order is implementation-defined (e.g., `kotlin.collections.Map` is a JVM `LinkedHashMap` in most cases, but the contract is unspecified). If a placeholder value contains another placeholder's key syntax (e.g., `value = "<other_placeholder>"`), the result depends on iteration order.
+
+**Why it matters:** Edge case (placeholder values normally don't contain `<...>` patterns), but the function is exposed for general use. Cheap to fix.
+
+**Suggested fix:** Sort the keys before iterating, or document that placeholder values must not contain other placeholder syntax.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/util/MiniMessageUtils.kt:191-192 — `deserializeLegacy` replaces every `&`, including literals
+
+**What:** `legacyText.replace('&', '\u00A7')` replaces *all* ampersands. A lore line like `"Coins: & 5"` becomes `"Coins: § 5"`.
+
+**Why it matters:** Cosmetic. Worth a defensive escape.
+
+**Suggested fix:** Document the constraint, or only do the replace if a recognized color-code suffix follows (e.g., `&[0-9a-fl-or]`).
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/util/ItemUtils.kt:310-318 — `isArmorMaterial` doesn't recognize `TURTLE_HELMET`, `LEATHER_HORSE_ARMOR`, `SADDLE`, etc.
+
+**What:** The substring check on `material.name` covers `LEATHER_`, `CHAINMAIL_`, `IRON_`, `GOLDEN_`, `DIAMOND_`, `NETHERITE_`. `TURTLE_HELMET` and `LEATHER_HORSE_ARMOR` are valid `ArmorMeta` materials but are not matched.
+
+**Why it matters:** When the config sets `trim` for a `TURTLE_HELMET` (which is a real thing in vanilla 1.21+), the trim is silently not applied. Cosmetic / feature gap.
+
+**Suggested fix:** Add the missing material names to the predicate, or replace with a positive `Material` allowlist.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/util/ItemUtils.kt:320-355 — `applyArmorTrim` falls through to random trim if `pattern`/`material` keys are empty strings
+
+**What:** `trimSection.getString("pattern", "")` returns `""` when the key is missing or empty. The registry lookup `Registry.TRIM_PATTERN.get(NamespacedKey.minecraft(""))` returns null, the `if (pattern != null && material != null)` is false, and the function falls into the `else` branch (line 339) and applies a *random* trim. A config that intentionally sets `pattern: ""` to mean "no trim" silently gets a random one instead.
+
+**Why it matters:** Cosmetic / config-author footgun. Not a security issue. Worth logging a debug or warn when pattern is explicitly empty.
+
+**Suggested fix:** When `patternKey.isBlank()`, skip trim application entirely (or accept an explicit `none` sentinel).
+
+**Confidence:** low
+
+---
+
+### [SEV: low] src/main/kotlin/net/lumalyte/lumasg/util/MeteorUtils.kt:180-196 — `spawnVisualDebris` `FallingBlock` entities are never cleaned up
+
+**What:** `world.spawnFallingBlock(...)` creates real entities. `dropItem = false` and `setHurtEntities(false)` are set, but there is no `setTicksLived(N)` cap, no scheduled removal, and no `setRemoveWhenFarAway(true)`. The entities live until they hit a solid block, the void, or vanilla despawn (5 minutes in most cases).
+
+**Why it matters:** A storm of meteor explosions in a short window can leave hundreds of falling blocks lingering in the world, which:
+- (a) chunks the world and bloats region files;
+- (b) can be visually confusing for players;
+- (c) can be picked up by a Paper bug where `dropItem = false` is ignored server-side under some conditions, silently restoring an item drop exploit.
+
+**Suggested fix:** `fallingBlock.setTicksLived(100)` (5 seconds) and `fallingBlock.removeWhenFarAway = true`. Or schedule a Bukkit task to remove them after N ticks. Verify Paper actually honors `dropItem = false` for `FallingBlock` spawned programmatically (it does in 1.20+, but the contract has changed historically).
+
+**Confidence:** med
+
+---
+
+## Test coverage gaps (named)
+
+| Where | Missing test | Suggested test name |
+|-------|-------------|---------------------|
+| `domain/PlayerStats.kt:27` | `kdr` is unbounded when `deaths == 0` | `PlayerStatsTest.kdr_unbounded_when_deaths_zero_does_not_throw_and_does_not_dominate_leaderboard` |
+| `util/InvitationManager.kt:29-35` | Removal listener must clean up `playerActiveInvitations` on TTL eviction | `InvitationManagerTest.expired_invitation_removes_playerActiveInvitations_entry` |
+| `util/InvitationManager.kt:46-63` | Concurrent `createInvitation` for the same invitee must not lose the newer mapping | `InvitationManagerTest.concurrent_createInvitation_for_same_invitee_keeps_newest_mapping` |
+| `util/InvitationManager.kt:89-95` | `acceptInvitation` removes the mapping in `playerActiveInvitations` | `InvitationManagerTest.acceptInvitation_clears_playerActiveInvitations` |
+| `util/InvitationManager.kt:103-111` | `declineInvitation` removes the mapping in `playerActiveInvitations` | `InvitationManagerTest.declineInvitation_clears_playerActiveInvitations` |
+| `util/InvitationManager.kt:127-142` | `removePlayerInvitations` clears both invitee and inviter roles | `InvitationManagerTest.removePlayerInvitations_clears_both_inviter_and_invitee_mappings` |
+| `util/ErrorHandlingUtils.kt:283-340` | `CircuitBreaker` opens after threshold and resets after timeout | `CircuitBreakerTest.opens_after_threshold_failures_and_resets_after_timeout` |
+| `util/ErrorHandlingUtils.kt:39-81` | `executeWithRetry` retries only recoverable errors | `ErrorHandlingUtilsTest.executeWithRetry_does_not_retry_non_recoverable_errors` |
+| `util/InventorySerializer.kt:43-55` | Fallback returns null, not an empty payload | `InventorySerializerTest.serializeInventory_returns_null_on_failure_not_empty_array` |
+| `util/InventorySerializer.kt:65-76` | Deserialization of corrupted Base64 returns null, not partial | `InventorySerializerTest.deserializeInventory_corrupted_base64_returns_null` |
+| `domain/Arena.kt:35-54` | `scanForChests` does not freeze the main thread for large radii | `ArenaTest.scanForChests_completes_within_main_thread_budget_for_default_radius` (likely a load test, not a unit test — mark as integration) |
+| `domain/ArenaTemplate.kt:19-25` | `applyTo` preserves non-templated fields exactly | `ArenaTemplateTest.applyTo_preserves_unrelated_fields` |
+| `util/ItemUtils.kt:195,180` | Configured enchantments above vanilla max are clamped | `ItemUtilsTest.createItemFromConfig_clamps_enchant_level_to_registry_max` |
+| `util/ItemUtils.kt:248-293` | Unknown potion effect type does not throw | `ItemUtilsTest.createItemFromConfig_unknown_potion_effect_type_logs_warning_and_skips` |
+| `util/MeteorUtils.kt:228-247` | Explosion damage falls off linearly with distance | `MeteorUtilsTest.spawnExplosion_damage_falls_off_linearly_with_distance` |
+| `util/MeteorUtils.kt:249-290` | `launchMeteor` handles `target == start` (zero distance) | `MeteorUtilsTest.launchMeteor_zero_distance_target_does_not_divide_by_zero` |
+| `util/MiniMessageUtils.kt:143-166` | `convertLegacyToMiniMessage` handles empty and unknown codes | `MiniMessageUtilsTest.convertLegacyToMiniMessage_handles_empty_string_and_unknown_codes` |
+| `util/MiniMessageUtils.kt:70-77` | `parseMessage` with empty placeholder map works | `MiniMessageUtilsTest.parseMessage_with_empty_placeholders_returns_parsed_component` |
+| `permissions/RankPermissions.kt:46-47` | `hasAdminAccess` is true for OPs even without explicit permission | `RankPermissionsTest.hasAdminAccess_true_for_op_players` |
+| `permissions/RankPermissions.kt:49-55` | `getPermissionLevel` ordering (admin > moderator > leader > player > guest) | `RankPermissionsTest.getPermissionLevel_returns_correct_level_for_each_tier` |
+| `util/ConfigurationManager.kt:30-39` | `init` does not crash when a default resource is missing | `ConfigurationManagerTest.init_succeeds_when_a_default_config_is_missing` (defensive test) |
+| `util/ConfigurationManager.kt:61-87` | `updateConfig` preserves existing user values | `ConfigurationManagerTest.updateConfig_preserves_user_values` |
+| `util/ConfigurationManager.kt:111-142` | `updateConfigSection` adds missing nested sections | `ConfigurationManagerTest.updateConfigSection_adds_missing_nested_section` |
+| `util/InvitationManager.kt:153-158` | `getStats` does not throw when cache is empty | `InvitationManagerTest.getStats_empty_cache_returns_string_with_zero_size` |
+| `util/InventorySerializer.kt:122-136` | `calculateSize` with empty array does not produce NaN | `InventorySerializerTest.calculateSize_empty_array_returns_zero_average` |
+| `util/MeteorUtils.kt:138-148` | `spawnGroundCircle` handles negative and zero radius | `MeteorUtilsTest.spawnGroundCircle_zero_radius_does_not_throw` |
+
+---
+
+## Methodology notes
+
+- No SQL strings were found in this batch; the SQL-injection check is N/A.
+- No secret material (tokens, webhooks) is hardcoded; the secret-leakage check is N/A.
+- No Java native deserialization is used; NBT (`ItemStack.serializeAsBytes`) is safe-by-construction.
+- No path-traversal sinks in this batch.
+- All Bukkit-thread concerns are listed under thread-safety in their respective findings.
+- Confidence labels are calibrated to "high" when the failure mode is provable from the code alone, "med" when it depends on a consumer (e.g., `StatType.columnName` accuracy depends on the leaderboard SQL), and "low" when the impact is mostly cosmetic / future-proofing.

--- a/docs/audit/audit-game.md
+++ b/docs/audit/audit-game.md
@@ -1,0 +1,235 @@
+# Audit Report: audit-game
+
+Scope: `src/main/kotlin/net/lumalyte/lumasg/game/*.kt` (16 files). Focus: dupe-exploits, game-state desync, save/restore correctness, test coverage.
+
+Existing test coverage in this package: only `GameLifecycleTest` (2 trivial data-model tests) and `GameProfilerTest`. The rest of the game/ package is untested.
+
+---
+
+### [SEV: crit] game/PlayerStateManager.kt:61 — `saveLocation=false` corrupts the saved location field
+**What:** When `config.game.saveLocation` is false, the saved `location` is set to `spawnLocation` (the arena spawn the player was just teleported to), not the player's pre-game position. On restore, the player is teleported to the arena spawn — not their original location.
+**Why it matters:** An admin who disables `saveLocation` expects the lobby destination to take over; instead, players are dumped back at an arbitrary arena spawn. If the game world is unloaded by the time restore runs, `player.teleport(spawnLocation)` may NPE or teleport to a now-invalid world, or strand the player inside a still-loaded arena. The field silently lies about what it represents.
+**Suggested fix:** Make `SavedState.location` nullable; only populate it when `saveLocation=true`. In `restore`, treat `null` as "use lobby".
+**Confidence:** high
+
+---
+
+### [SEV: crit] game/Game.kt:164 — `reconnectPlayer` overwrites the player's pre-game inventory with mid-game loot
+**What:** `reconnectPlayer` calls `playerStateManager.saveAndPrepare(player, spawn)`. `saveAndPrepare` writes the player's *current* inventory (mid-game loot) into the `saved` map, overwriting the original pre-game snapshot taken on first join.
+**Why it matters:** When the game later ends, `restoreAllPlayers` calls `restore`, which returns the player to the snapshot — which is now their mid-game loot, not the pre-game inventory. The player's real items are silently lost.
+**Suggested fix:** Skip `saveAndPrepare` on reconnect — the original saved state is already in the map. If a fresh teleport is needed, do it without re-snapshotting. Consider a separate `respawn` method that does only teleport + permission refresh.
+**Confidence:** high
+
+---
+
+### [SEV: crit] listeners/PlayerListener.kt:121-125 (game batch: same pattern in game/Game.kt:240-245 and game/Celebration.kt:240-245) — server-console command injection via `killCommand` / `winCommand`
+**What:** `config.rewards.killCommand` and `config.rewards.winCommand` are templates with `<player>` and `<kills>` replaced via naive `.replace("<player>", player.name)`. The resulting string is dispatched with `plugin.server.dispatchCommand(consoleSender, cmd)`.
+**Why it matters:** Player names flow into a server-console command without quoting or sanitisation. A name containing `;`, ` `, or other command separators causes the rest of the name to be interpreted as additional commands, executed as the *console* (highest privilege). The same pattern is used in three places (kill reward, win reward, celebration), all via the same template. Minecraft's name validation partially mitigates this, but nicknames/display-names/imported sources are not always validated.
+**Suggested fix:** Reject names containing `;`, ` `, or quote characters before substitution; or, better, split the command on the first space and only substitute into the first token, treating the rest as opaque arguments.
+**Confidence:** med
+
+---
+
+### [SEV: crit] game/TeamManager.kt:46-53 and game/TeamQueueManager.kt:82-83 — accepted invite can leave a player in two teams (dupe-exploit / oversized team)
+**What:** `TeamManager.acceptInvite` calls `team.add(invitee)` and `playerTeams[invitee] = team.id` without first removing the invitee from any existing team. `TeamQueueManager.accept` does the equivalent for the pre-game queue — `invitation.team.add(player.uniqueId)` is unconditional, and `preGameTeams[player.uniqueId] = invitation.team` overwrites the pointer while the old team's `members` list still contains the player.
+**Why it matters:** A player can belong to two teams at once. Both teams' `isAlive` / `isFull` checks can see the same player, breaking the `aliveTeams.size <= 1` win condition and effectively allowing a team to exceed `maxSize`. This is a direct dupe-exploit.
+**Suggested fix:** Before adding the player to the new team, iterate all teams (and `preGameTeams`) and remove the player's UUID. `TeamManager.acceptInvite` already calls `removeFromTeam(invitee)` on line 50, but only after `pendingInvites.remove` — verify the order is right. In `TeamQueueManager.accept`, add an explicit `for (t in preGameTeams.values) t.remove(player.uniqueId)` and remove from `preGameTeams` for any previous entry.
+**Confidence:** high
+
+---
+
+### [SEV: high] game/Team.kt:19-21 — `Team.isAlive` is false whenever a member is offline, even if not eliminated
+**What:** `val isAlive: Boolean get() = !isEliminated && members.any { Bukkit.getPlayer(uuid)?.isOnline == true }`. A team is "alive" only if at least one member is currently online. `eliminated` is not the deciding factor; online status is.
+**Why it matters:** `Game.checkWinCondition` (Game.kt:438-441) uses `teamManager.getAliveTeams()` to end the game. If all members of a team briefly disconnect (lag spike, server restart, network blip), the team becomes "dead" instantly and the opponent wins — even though the members are still in the game and will reconnect. A player can deliberately disconnect to force a 1-team-remaining win for the opposing side, or to grief their own team by making them appear eliminated. The team's `eliminate()` is never called, so `isEliminated` stays false; the alive state simply gets re-derived as false the moment the last member goes offline.
+**Suggested fix:** Track a per-team eliminated flag (set by `eliminate()`) and base `isAlive` only on `!isEliminated`. Disconnect should *not* mark the team as dead; the alive player set is something the game tracks separately from the `Team` value object.
+**Confidence:** high
+
+---
+
+### [SEV: high] game/Game.kt:138-151 — `eliminate(uuid)` mutates state for UUIDs that are not in the game
+**What:** The function unconditionally removes from `disconnectedPlayers`, prepends to `eliminationOrder`, calls `teamManager.removeFromTeam(uuid)`, and either adds to `spectators` or calls `removePlayer(player)` — even when `_players[uuid]` is null.
+**Why it matters:** A buggy caller (or a double-eliminate, or a stale event after the player was already removed) leaves ghost entries in `eliminationOrder`, `spectators`, and possibly removes a real member from a team. `allParticipants()` (Game.kt:188) returns `_players.keys + spectators`, so ghost spectators are sent death/border messages and included in celebration `participants`. Persistence then records a winner for a ghost UUID. The class has no precondition to assert the UUID is a member.
+**Suggested fix:** Add `if (_players[uuid] == null) return` at the top. Idempotent eliminate should also short-circuit when `_players[uuid]?.isAlive == false`.
+**Confidence:** high
+
+---
+
+### [SEV: high] game/WorldManager.kt:33, 46-47, 192-199 — cleanup overwrites world border with the uninitialised default if `setup()` is skipped
+**What:** `originalBorderSize` is initialised to `60_000_000.0` (line 33). If `setup()` early-returns (e.g., `arenaWorld()` or `arenaCenter()` returns null), the snapshot is never taken. `cleanup()` then unconditionally calls `restoreWorldSettings`, which sets the border to `60M` — clobbering whatever border the world actually had.
+**Why it matters:** State corruption reachable when an arena's world fails to load (renamed, unloaded, worldName typo). A second, unrelated game on the same world would have its border reset to 60M. The "no-op" path is destructive.
+**Suggested fix:** Add a `private var snapshotTaken: Boolean = false` set to `true` in `setup()` after the snapshot, and guard `restoreWorldSettings` on it.
+**Confidence:** med
+
+---
+
+### [SEV: high] game/NameplateManager.kt:30-35, 44-49 — `stop()` and `disableNameplateHiding()` launch fire-and-forget coroutines
+**What:** Both methods call `scope.launch { withContext(bukkitDispatcher) { restoreAll() } }` without awaiting. The launched coroutine is decoupled from the caller.
+**Why it matters:** `stop()` is called from `Game.endGame` and `Game.cleanup` (Game.kt:452, 481). After `endGame` returns, `scope.cancel("Game ended")` is invoked (Game.kt:475). The fire-and-forget restore coroutine may be cancelled before it runs, leaving players with `hideEntity` applied. The next time they enter a normal server context, they can see other players, but the `visibility` map is also not cleared (the `visibility.clear()` is inside `restoreAll`), so the next game's `start` would observe stale state.
+**Suggested fix:** Make `stop()` a `suspend` function (or expose a `suspend fun stopSuspending()`) and await the restore. If the caller can't suspend, use a `CompletableDeferred<Unit>` and wait. Or, since the main thread is required, call `restoreAll()` synchronously from the caller when the caller is already on the main thread.
+**Confidence:** med
+
+---
+
+### [SEV: med] game/Game.kt:162 — `reconnectPlayer` picks a non-deterministic spawn point
+**What:** `val spawn = arena.spawnPoints.getOrNull(_players.keys.toList().indexOf(player.uniqueId))?.toBukkit()`. The `.toList()` on a `ConcurrentHashMap` is non-deterministic; the order is unspecified. The reconnecting player can spawn at any of the configured spawn points (or fall back to center) regardless of where they originally were.
+**Why it matters:** A player who legitimately disconnects and reconnects can respawn at a different team's spawn, into a danger zone, or in the deathmatch inner ring. The "spawn point" is effectively a coin flip.
+**Suggested fix:** Persist the player's original spawn index on the `GamePlayer` value (e.g., `var spawnIndex: Int = -1`) when they first join, and use that on reconnect.
+**Confidence:** high
+
+---
+
+### [SEV: med] game/Game.kt:106-108 — `addPlayer` spawn index is total count, including eliminated-in-map players
+**What:** The spawn index is `arena.spawnPoints.getOrNull(_players.size)`. `_players` includes eliminated-but-spectating players (their `isAlive` is false but they remain in the map). If 12 spawn points are configured and the 12th player is eliminated (still in `_players`), the 13th joiner gets `arena.center` (the fallback) instead of an actual spawn point.
+**Why it matters:** Two players end up at the same fallback (center) when there are still free spawn points. Centre-fallback usually overlaps with the deathmatch inner ring or a hazard — minor gameplay bug, but it's a state desync with the configured layout.
+**Suggested fix:** Index off `players.count { it.value.isAlive }` or store a monotonic `nextSpawnIndex` counter on the game.
+**Confidence:** med
+
+---
+
+### [SEV: med] game/Game.kt:66, 141 — `eliminationOrder` is a non-thread-safe `mutableListOf`
+**What:** `private val eliminationOrder = mutableListOf<UUID>()` (line 66). `eliminate()` calls `eliminationOrder.add(0, uuid)` (line 141) from coroutine code that may be on any dispatcher, including the main thread during event handlers and the Bukkit dispatcher in other paths.
+**Why it matters:** Two near-simultaneous eliminations (e.g., a multi-kill, AoE damage killing two players, or events from different threads) can race on the underlying `ArrayList`. Resulting behaviour ranges from silent corruption to `IndexOutOfBoundsException` (the add-at-zero shifts the whole backing array).
+**Suggested fix:** Use `java.util.Collections.synchronizedList(mutableListOf())` or switch to a `CopyOnWriteArrayList` (writes are rare relative to reads, fits the access pattern).
+**Confidence:** med
+
+---
+
+### [SEV: med] game/Celebration.kt:80-102 — unbounded image fetch and decode from external URL
+**What:** `renderPixelArtHead` calls `URL(apiUrl).openConnection().getInputStream()` and decodes the result with `ImageIO.read()`. The URL is templated from `config.rewards.winnerAnnouncement.pixelArt.apiUrl` (admin-controlled), but the substitution does not URL-encode `<name>`. No size cap, no content-type check, no domain pinning.
+**Why it matters:** ImageIO is a known DoS surface (decompression bombs, oversized image allocations). With a 5-second read timeout a slow trickle is bounded, but a single multi-megapixel PNG or animated GIF can OOM the JVM. SSRF is also possible if the admin mistypes the URL: `http://internal-service/...` would be fetched from the game server.
+**Suggested fix:** URL-encode `<name>` and `<uuid>`; pin the host to the configured skin service; cap the download with `conn.setRequestProperty("Range", "bytes=0-1048576")` and reject anything past 1 MB; verify `Content-Type` starts with `image/`.
+**Confidence:** med
+
+---
+
+### [SEV: med] game/Game.kt:552-555 — `broadcastDeathMessage` ignores configured death/kill templates
+**What:** `broadcastDeathMessage` calls `deathMessage(victim, killer)` with the default `config = null` parameter. The `deathMessage` function then uses its hardcoded fallback templates instead of `config.messages.deathNatural` and `config.messages.deathByPlayer`.
+**Why it matters:** Server admins who customised the death/kill message templates in config will silently see the hardcoded defaults. The configured template is read nowhere. `killNotification` has the same problem.
+**Suggested fix:** Pass `config`: `val msg = deathMessage(victim, killer, config)`. Same for the kill notification.
+**Confidence:** high
+
+---
+
+### [SEV: med] game/GameBarrierManager.kt:23-28 and game/WorldManager.kt:73-78 — `for` over a `ConcurrentHashMap` followed by `clear()` is correct but subtle
+**What:** Both barrier managers iterate `barriers.entries` to restore blocks, then call `barriers.clear()`. The iteration is weakly consistent on a `ConcurrentHashMap`, so a concurrent `placeBarrier` (which can happen on the main thread from `runLifecycle`) can interleave.
+**Why it matters:** If a `placeBarrier` runs concurrently with `removeAll`, the new barrier is stored in the map but is not restored (because the iteration has already passed that key), and `clear()` removes it from the map — leaving a permanent `Material.BARRIER` block in the world. The race is small (both call sites are wrapped in `withContext(bukkitDispatcher)`, so they should not overlap), but it depends on every caller honouring that contract.
+**Suggested fix:** Document the main-thread requirement with `@MainThread` and add a `check(Bukkit.isPrimaryThread())` assertion. Or, swap the data structure for one that supports atomic swap-and-iterate (e.g., copy-on-write snapshot).
+**Confidence:** med
+
+---
+
+### [SEV: med] game/GameScoreboard.kt:46, 67-75 — non-thread-safe `participants` mutated from multiple threads
+**What:** `private val participants = mutableSetOf<UUID>()` (line 46). `addPlayer`/`removePlayer` (lines 67-75) mutate it directly. `start()`'s render coroutine reads it on the Bukkit dispatcher, and `addPlayer` is called from listeners on the main thread — but `addPlayer` is also called from `reconnectPlayer` and from `addSpectator` inside coroutine code dispatched to the main thread. In practice everything lands on the main thread, but the type gives no guarantee.
+**Why it matters:** A future refactor that calls `addPlayer` from a non-main thread (e.g., a coroutine resumed off-thread) would cause `ConcurrentModificationException` or silent loss of scoreboard membership. The `GameScoreboard` class doesn't enforce main-thread access.
+**Suggested fix:** Switch to `Collections.newSetFromMap(ConcurrentHashMap())` and add a `check(Bukkit.isPrimaryThread())` in mutation methods.
+**Confidence:** low
+
+---
+
+### [SEV: low] game/Game.kt:181-186 — `removePlayer(Player, Boolean, Boolean)` accepts parameters it never reads
+**What:** `removePlayer(player: Player, teleportToLobby: Boolean = true, restoreState: Boolean = true)` declares two parameters. The body uses neither; teleport/restore is controlled entirely by `config.lobby.teleportOnEnd` and `config.game.restoreInventory` in `PlayerStateManager.restore`.
+**Why it matters:** Misleading API. Callers think they can override the policy per call but cannot. Dead parameters become load-bearing if someone "fixes" the implementation by actually honouring them, breaking the existing flow.
+**Suggested fix:** Remove the parameters, or wire them through to `PlayerStateManager.restore` and the teleport decision.
+**Confidence:** high
+
+---
+
+### [SEV: low] game/Celebration.kt:83-88 — `URLConnection.getInputStream()` is not closed
+**What:** The `try` block returns `ImageIO.read(conn.getInputStream())` and the catch returns `null`. The stream is never closed in a `finally` block. The connection's underlying socket is eventually finalised, but not promptly.
+**Why it matters:** Resource leak. Under high frequency (many short games), file descriptors and sockets can accumulate. A common minor finding, especially with HTTP keep-alive.
+**Suggested fix:** Use Kotlin's `.use { }` extension on the stream; or wrap in try/finally with explicit `close()`.
+**Confidence:** med
+
+---
+
+### [SEV: low] game/TeamQueueManager.kt:125-138 — `broadcastQueueStatus` is O(online × activeGames) per tick
+**What:** The inner loop checks `gameManager.getGameForPlayer(player.uniqueId) == null` for every online player. `getGameForPlayer` iterates `activeGames.values`. With N online players and M games, this is O(N×M) per broadcast.
+**Why it matters:** Performance, not correctness. With many simultaneous games and a busy server, the broadcast tick can be slow.
+**Suggested fix:** Build a `Set<UUID>` of all in-game UUIDs once per tick (or once per `activeGames` change), then check membership in O(1) per player.
+**Confidence:** low
+
+---
+
+### [SEV: low] game/Game.kt:101-103 — `addDummy` is a public, production-visible testing API
+**What:** `addDummy` adds a non-`Player` entry to `_players` directly, bypassing the scoreboard, state save, and `PlayerStateManager` setup that real joiners get. The function is `fun` (public) with no annotation marking it test-only.
+**Why it matters:** A bug elsewhere (a misconfigured command handler, a stale admin script) could call `addDummy(realUuid, realName)`, double-counting that player in `alivePlayers`, `getPlayerCount`, and the win-condition check. There's no guard rejecting the call when real players are present.
+**Suggested fix:** Mark it `internal` (Kotlin's module-scoped) or wrap in an `if (Bukkit.getPlayer(uuid) == null) { ... }` guard. Better: gate on a `dev` mode flag.
+**Confidence:** low
+
+---
+
+### [SEV: low] game/WorldManager.kt:183-190 — `clearDrops` uses hardcoded 300-block radius
+**What:** `clearDrops` filters by `it.location.distanceSquared(center) <= 300.0 * 300.0`, ignoring `arena.radius`. The sibling `clearAllDrops` (line 141) correctly uses `arena.radius`.
+**Why it matters:** For arenas with `radius > 300`, items outside 300 but inside the arena persist past game end. For arenas with `radius < 300`, items in the unselected band are also cleared (probably desired). The two methods disagree about scope, which is a smell.
+**Suggested fix:** Use `arena.radius` in both, or delete `clearAllDrops` if `clearDrops` is the only caller.
+**Confidence:** low
+
+---
+
+### [SEV: low] game/GameScoreboard.kt:103-105 — scoreboard re-assigned on every render tick
+**What:** `render()` iterates `participants.toList()` and writes `Bukkit.getPlayer(id)?.scoreboard = scoreboard` every 2 seconds. This is the *same* scoreboard object the player already has.
+**Why it matters:** Setting the scoreboard repeatedly forces the client to re-render the sidebar, causing visible flicker on some clients and wasting packets. There's no `if (p.scoreboard != scoreboard)` guard.
+**Suggested fix:** Only assign when the current player's scoreboard differs from the game's.
+**Confidence:** low
+
+---
+
+### [SEV: low] game/TeamManager.kt:41 — cryptic `?.isFull != false` check
+**What:** `if (getTeamForPlayer(inviter)?.isFull != false) return false`. Reads as "if inviter has no team, return false; if inviter's team is full, return false" but is hard to verify.
+**Why it matters:** Style/maintainability. Easy to misread; future refactors could invert the logic accidentally.
+**Suggested fix:** Rewrite as `val team = getTeamForPlayer(inviter) ?: return false; if (team.isFull) return false`.
+**Confidence:** high
+
+---
+
+### [SEV: low] game/GameSetupValidator.kt:58-64 — `lobbySpawn`/`spectatorSpawn` issues are reported but don't gate `isSetupComplete`
+**What:** `validate` adds issues for missing `lobbySpawn` and `spectatorSpawn`, but `isSetupComplete` (lines 70-77) doesn't check them, and no other code rejects an arena that has no lobby.
+**Why it matters:** Admins see a warning but can still host games that lack a lobby spawn. Players will spawn at "arena center" per the message, but that's a surprise, not a planned fallback. Inconsistent validation.
+**Suggested fix:** Decide if these are warnings (keep in `validate`, exclude from `isSetupComplete`) or blocking (add to `isSetupComplete`). Be explicit.
+**Confidence:** low
+
+---
+
+### [SEV: low] game/Game.kt:445-447 — `skipGracePeriod` is a no-op stub
+**What:** `skipGracePeriod` has an empty body with a comment "sets grace remaining to 1". It doesn't actually do anything.
+**Why it matters:** A debug command calling this will appear to work (no exception) but the grace period will not skip. Operators will be confused. Dead method.
+**Suggested fix:** Either implement it (set a flag the `runGracePhase` loop checks) or delete the function and the calling command.
+**Confidence:** high
+
+---
+
+### [SEV: low] game/GameManager.kt:144-150 — `shutdown` doesn't await coroutine completion before clearing the registry
+**What:** `shutdown` cancels every game's scope and then immediately clears `activeGames`. The `invokeOnCompletion` handlers may still be queued, but `activeGames` is already empty by the time they run — their `activeGames.remove(game.id)` is a no-op. Cancellation is asynchronous; cleanup coroutines (including `Celebration`'s fireworks) can be in-flight when the JVM proceeds to stop the plugin.
+**Why it matters:** A reload right after shutdown may see partial state. Fireworks spawned during shutdown may leak entities. Defensive-coding nit.
+**Suggested fix:** After cancelling all scopes, run a brief `runBlocking { activeGames.values.forEach { it.scope.coroutineContext[Job]?.join() } }` (with a timeout) before clearing.
+**Confidence:** low
+
+---
+
+### [SEV: low] game/Game.kt:188, 222, 562-565 — `allParticipants` and `broadcast` allocate new collections on every call
+**What:** `allParticipants()` returns `_players.keys + spectators`, which constructs a new `LinkedHashSet` on every call. `broadcast` iterates it. Hot paths (every render tick, every death message) pay this cost.
+**Why it matters:** Minor allocation churn. Not a bug, just defensive-coding nit.
+**Suggested fix:** Cache the set, invalidate on `addPlayer`/`removePlayer`/`eliminate`.
+**Confidence:** low
+
+---
+
+## Test-coverage gaps
+
+The following untested behaviour is the most important missing coverage in this batch. Each would catch a finding above.
+
+1. **`PlayerStateManager.saveAndPrepare` with `saveLocation=false`** — assert the saved `location` is null/center (per the intended fix), not the arena spawn. Would catch the critical bug at PlayerStateManager.kt:61.
+2. **`Game.reconnectPlayer` preserves the original saved state** — call `addPlayer`, set a marker item in the player's inventory, mutate the inventory to game loot, call `handleDisconnect` + `reconnectPlayer`, then `restoreAllPlayers`, and assert the marker item is still there. Would catch the data-loss bug at Game.kt:164.
+3. **`Team.isAlive` with all members offline** — construct a team, set members to UUIDs of offline players, assert `isAlive` is true (or whatever the intended contract is). Would catch the high-severity desync at Team.kt:19.
+4. **`TeamManager.acceptInvite` rejects a player already in a different team** — pre-populate the player in team A, accept an invite to team B, assert membership is in B and *not* in A. Would catch the dupe-exploit at TeamManager.kt:46.
+5. **`Game.eliminate` is a no-op for unknown UUIDs** — call with a fresh UUID, assert `eliminationOrder`, `spectators`, and team state are unchanged. Would catch the state desync at Game.kt:138.
+6. **`Game.addPlayer` allocates distinct spawns with eliminated players in the map** — pre-populate 12 players (one eliminated), add a 13th, assert the new player gets spawn index 12, not the center fallback. Would catch Game.kt:106.
+7. **`Game.eliminate` concurrent calls** — two `eliminate` calls in parallel (`Dispatchers.Default + runBlocking`) must not throw and must produce the correct order. Would catch the `mutableListOf` race at Game.kt:141.
+8. **`Celebration.renderPixelArtHead` rejects oversized/malformed images** — point the configured URL at a 100 MB PNG, assert the function returns null/throws without OOM. Would catch Celebration.kt:80.
+9. **`WorldManager.cleanup` after skipped `setup()`** — call `cleanup()` without `setup()`, assert the world border is *not* modified. Would catch WorldManager.kt:33.
+10. **`Game.broadcastDeathMessage` uses configured templates** — set a custom `messages.deathNatural`, kill a victim, assert the broadcast contains the custom string. Would catch Game.kt:554.
+11. **`TeamQueueManager.accept` removes the player from any prior pre-game team** — accept an invite while already in another pre-game team, assert membership in only one team. Would catch TeamQueueManager.kt:82.
+12. **`Game.skipGracePeriod` actually skips the grace period** — would catch the no-op stub at Game.kt:445.
+13. **`NameplateManager.stop` restores visibility synchronously** — set up hidden state, call `stop`, assert the player can see other players immediately. Would catch NameplateManager.kt:30.
+14. **`Game.removePlayer(Player, false, false)` honours the parameters** — call with restoreState=false, assert the inventory is *not* restored. Would catch the dead-parameter finding at Game.kt:181 (or be deleted if the parameters are removed).
+15. **`Game.addDummy` is unreachable from production code paths** — verify the function is `internal` (or guarded), so a non-test command cannot introduce ghosts. Would catch the Game.kt:101 finding.

--- a/docs/audit/audit-gui-commands.md
+++ b/docs/audit/audit-gui-commands.md
@@ -1,0 +1,164 @@
+Audit Report: audit-gui-commands
+================================
+Scope: src/main/kotlin/net/lumalyte/lumasg/commands/SGCommand.kt
+       src/main/kotlin/net/lumalyte/lumasg/gui/{ArenaSelectionMenu,GameBrowserMenu,LeaderboardMenu,MainMenu,MenuUtils,SetupMenu,SpectatorMenu,TeamSelectionMenu}.kt
+       src/main/kotlin/net/lumalyte/lumasg/listeners/{AdminWandListener,ChestListener,CustomItemListener,FishingListener,PlayerListener}.kt
+Files read: 14
+Findings: 20
+
+============================================================
+CRITICAL
+============================================================
+
+### [SEV: crit] listeners/AdminWandListener.kt:88-99 — Wand edits to arenas are not persisted to the database
+**What:** `onInteract` updates the arena via `arena.copy(spawnPoints = …)` and calls `arenaService.addToCache(updated)`. `addToCache` (ArenaService.kt:53) only mutates the in-memory `cache` map; it does not call `arenaRepo.save(...)`. The next time `ArenaService.loadAll()` runs (e.g., on `/sg admin reload` or server restart) the arena is re-read from the database, so every spawn point and arena center set with the wand is silently lost.
+**Why it matters:** This is a data-loss bug reachable in normal use. Admins will spend time carefully placing spawn points, restart the server, and find the arena reverted. The companion `create` subcommand (SGCommand.kt:460) does persist because it uses the suspending `arenaService.createArena`; the wand path silently diverges.
+**Suggested fix:** Make `addToCache` suspending and have it call `arenaRepo.save(arena)` (or expose a separate `saveArena(arena)` and call that from the listener). Better, replace the ad-hoc `addToCache` writes with a single suspend `arenaService.setSpawnPoint(...)` / `setCenter(...)` that persists.
+**Confidence:** high
+
+### [SEV: crit] gui/GameBrowserMenu.kt:65-77 — Players can join games already in Active/Deathmatch phase
+**What:** The click handler only checks `isPlayerInGame` and the size cap; it never inspects `game.phase`. The lore even displays the current phase, but the button is enabled regardless. `Game.addPlayer` itself has no phase guard (Game.kt:105), so a click on an in-progress game teleports the player in, runs `playerStateManager.saveAndPrepare`, and adds them to a live match. Same risk in the per-arena join path exposed by `SGCommand.start` → click flow.
+**Why it matters:** Game-integrity exploit. A player (or admin abusing `addplayer`) can join mid-fight, appearing at a fresh spawn inside the arena with their pre-game loadout. Spectators also gain the ability to re-enter as live players. Combined with the spectator/elimination handling, this is a complete state desync between game phase and player state.
+**Suggested fix:** Reject the click unless `game.phase is GamePhase.Waiting || game.phase is GamePhase.Countdown`, and surface a message to the viewer. The browser should also visually grey out (or omit) buttons for games in Active/Deathmatch/Grace.
+**Confidence:** high
+
+============================================================
+HIGH
+============================================================
+
+### [SEV: high] commands/SGCommand.kt:434-464 — `@Async` `create` command touches Bukkit API off the main thread
+**What:** `create` is annotated `@Async` and `suspend`, but inside the body it reads `player.location` (line 460, passed to `arenaService.createArena(...)`) and calls `player.sendMessage(...)` at lines 446, 449, 457, 462, 463. The Nexus `@Async` annotation dispatches the coroutine to a worker pool, not the Bukkit main thread; reading `Player.location` and invoking `Player.sendMessage` from a non-Bukkit thread is a classic main-thread violation that Paper will eventually guard with hard exceptions.
+**Why it matters:** Correctness. Under load this can throw `IllegalStateException("Player accessed from async thread")` or, worse, produce silently stale/half-applied state. The other `@Async` handlers in this file (`stats`, `leaderboard`) only touch `sender.sendMessage` after database calls, but `create` is far heavier on Bukkit API.
+**Suggested fix:** Drop `@Async` (the operation is trivially fast and only writes one DB row), or wrap the Bukkit-touching code in `withContext(bukkitDispatcher) { ... }` before/after the repository call. The same pattern needs auditing in any future `@Async` subcommand.
+**Confidence:** high
+
+### [SEV: high] commands/SGCommand.kt:296-319 — `/sg forcestart` is a complete no-op
+**What:** `forceStart` validates that the game exists, is in `Waiting`, and has at least one player, then sends a confirmation message. There is no code path that changes `game.phase`, cancels the countdown, or otherwise advances the game. The inline comment even concedes the command "doesn't" do anything beyond a message.
+**Why it matters:** Logic bug that breaks a feature. The `/sg forcestart` command is documented in the help text (line 599) and listed in the admin guide; running it is indistinguishable from a successful start to the operator even though nothing happened. This also defeats the "min players" gating that is presumably the whole point of the command.
+**Suggested fix:** Implement the actual force-start. `Game` exposes `cancelCountdown()` (Game.kt:225) and a `skipGracePeriod()` stub (Game.kt:445, currently empty). Either skip directly to the countdown's terminal tick and set `phase = GamePhase.Grace`, or call into a new `Game.forceStart()` that bypasses the countdown loop.
+**Confidence:** high
+
+### [SEV: high] listeners/CustomItemListener.kt:140-179 — Bomb damage bypasses friendly-fire / phase rules
+**What:** `onBombExplode` calls `world.getNearbyEntities(...).filterIsInstance<Player>()` and applies `target.damage(damage)` and a custom `target.velocity` knockback, filtering only by `throwerId`. It does not check `game.phase`, `isPvpEnabled()`, or `config.game.teams.friendlyFire`. The general `PlayerListener.onEntityDamage` guard (PlayerListener.kt:51) is bypassed entirely because the damage originates from `Entity.damage()`, not from a Bukkit damage event of the right class.
+**Why it matters:** Game-integrity exploit. In a team game with `friendlyFire = false`, throwing a bomb at a teammate deals damage and knockback that the normal friendly-fire handler would have cancelled. In Waiting/Countdown/Grace phases, bombs still hurt and shove players around. The same is true for the Poison Bomb handler (line 196-217) and the Fire Bomb (line 75-110), though fire is indirect.
+**Suggested fix:** Resolve the thrower's `Game` and the target's `Game` from `gameManager`, then enforce the same rules `PlayerListener` uses (phase gate, friendly-fire, target-is-alive). Skip damage/knockback when the rules say no PvP. Apply damage via a synthetic `EntityDamageByEntityEvent` (or use Bukkit's damage source API) so existing listeners can intercept it.
+**Confidence:** high
+
+### [SEV: high] listeners/ChestListener.kt:57-88 — Cross-arena chest filling when multiple arenas share a world
+**What:** `onChunkLoad` finds "the game running in this world" by scanning `getAllActiveGames()` for any game whose `arena.worldName == worldName`. If two arenas (e.g., a 50-player "lobby" arena and a 24-player "duels" arena) are both loaded and active in the same world, the loop uses the *first* matching game to call `determineTier(state, game)` and `fillChestSync(state, tier, game.lootMode)` for every chest in the chunk, including chests in the *other* arena's bounds.
+**Why it matters:** Game-integrity. Chests in arena B get filled with arena A's loot table and tier. The same bug applies to `onChestOpen` (line 96-115), which uses `gameManager.getGameForPlayer(player)` to find the game, but the world-arena collision is most visible on chunk load because chunk loading is a server-wide event, not per-player. The `filledChests` set is also global to the listener, so two games in the same world share the same "already filled" tracking.
+**Suggested fix:** Scope the fill to chests whose block location is actually inside the game's arena (e.g., `chest.location.distanceSquared(arena.center.toBukkit()!!) <= arena.radius^2`). Pass the world via the chunk and resolve the correct game by arena, not by world. Consider keying `filledChests` by `Pair<arenaName, location>` to keep games isolated.
+**Confidence:** high
+
+============================================================
+MEDIUM
+============================================================
+
+### [SEV: med] listeners/ChestListener.kt:165-166 — `toBlockKey` has hash collisions that cause chests to be skipped
+**What:** `Location.toBlockKey()` returns `(blockX shl 32) or (blockZ and 0xFFFFFFFF) xor (blockY shl 48)`. Mixing `|` and `^` at the same precedence means the expression parses as `((x shl 32) | (z & mask)) xor (y shl 48)`. The top 16 bits of the result are `xUpper XOR y` — so two distinct triples such as `(x=0, y=5, z=0)` and `(x=5, y=0, z=0)` produce the same key. Chests at those locations collide in `filledChests` (a `Set`), and the second one to be considered is treated as "already filled" and silently skipped.
+**Why it matters:** Chests can end up empty inside a round, with no error. The bug only triggers for positions whose y differs from some xUpper by XOR, but those positions are common in normal arenas.
+**Suggested fix:** Replace the key with a stable, collision-free encoding — e.g. `(x.toLong() and 0xFFFFFFL) shl 40 or ((z.toLong() and 0xFFFFFFL) shl 16) or (y.toLong() and 0xFFFFL)`, or better, use `Location.toBlockKey()` from Paper directly, or use a `Set<Location>` (block locations are short-lived) or a nested `Map<String, ConcurrentHashMap.KeySetView<Location>>` keyed by arena name.
+**Confidence:** high
+
+### [SEV: med] listeners/PlayerListener.kt:107-131 — `onPlayerDeath` schedules elimination in a coroutine that the game scope may have already cancelled
+**What:** `event.isCancelled = true; event.drops.clear(); game.scope.launch { game.eliminate(...); ... }`. `game.scope` is the per-game `SupervisorJob` (Game.kt:55-59). If the game has been stopped (`/sg stop` or end of game) between the death event firing and the coroutine resuming, `scope.launch` will throw `CancellationException` and the body — including kill recording, rewards, spectator mode — never runs. The death message has already been cleared, so the player just dies silently with no record of the kill, no reward, and (depending on the timing) potentially stuck in non-spectator mode mid-air waiting for the respawn handler.
+**Why it matters:** Edge-case bug. During the brief window where the game scope is being torn down, deaths are lost. It also makes the "kill commands" reward unreliable — a kill command can vanish.
+**Suggested fix:** Drive the death bookkeeping on the main thread (it's already running there) for the parts that must succeed (`drops.clear()`, `eliminate`'s state mutations), and only defer the async parts (stats save, reward dispatch) using a scope that survives game teardown, e.g. `plugin.scope` or a dedicated executor. At minimum, wrap the coroutine launch in a try/catch and log a warning.
+**Confidence:** med
+
+### [SEV: med] listeners/PlayerListener.kt:135-147 — Spectator mode applied one tick after respawn; player briefly vulnerable
+**What:** `onPlayerRespawn` only sets `event.respawnLocation`; the actual `player.gameMode = GameMode.SPECTATOR` is scheduled with `runTaskLater(..., 1L)`. For that one tick the player is alive (game mode `SURVIVAL`), at a spawn point inside the arena, with their pre-death inventory. If anything in that window fires a damage event or pickup, the normal in-game handlers (pvp, item pickup, etc.) will treat them as a live participant.
+**Why it matters:** Edge-case bug. With Paper's typical 50ms tick, the window is short, but a fast attacker or a delayed projectile can damage/kill the "spectator" during it, which is also a state desync between the death event and the spectator mode.
+**Suggested fix:** Set `player.gameMode = GameMode.SPECTATOR` synchronously in the respawn handler, or use `event.player.setGameMode(GameMode.SPECTATOR)` before the method returns. Respawn location can stay scheduled if needed.
+**Confidence:** med
+
+### [SEV: med] listeners/PlayerListener.kt:51-89 — Eliminated/spectator players still receive damage events
+**What:** `eliminate` flips `isAlive = false` and moves the UUID into `spectators`, but the UUID stays in `_players`, so `gameManager.getGameForPlayer(uuid)` still returns the game. The `onEntityDamage` and `onDamage` handlers therefore run for dead/spectating players. Spectator mode prevents most damage at the Paper level, but the `onDamage` tracker still increments `damageTaken`/`damageDealt` (PlayerListener.kt:99-103) on any event that slips through (e.g., direct `target.damage(damage)` from CustomItemListener).
+**Why it matters:** Game-integrity. Combined with the bomb/poison findings, the stats counters are polluted by post-elimination damage. The friendly-fire skip in the `else` branch (line 80-86) also runs for dead players, which is meaningless but harmless.
+**Suggested fix:** Early-out in both handlers if `game.players[uuid]?.isAlive == false` (or `uuid in game.spectators`). This also makes the custom-item findings above easier to write correctly.
+**Confidence:** med
+
+### [SEV: med] gui/GameBrowserMenu.kt:71-76 — TOCTOU race allows `maxPlayers` overflow on click
+**What:** The click handler reads `game.players.size >= game.arena.maxPlayers` and then calls `game.addPlayer(viewer)` unconditionally. Between the check and the add, other concurrent clicks (each running on the main thread but interleaved at tick boundaries) can push the player count over `maxPlayers`. There is no synchronized capacity check inside `Game.addPlayer` either (Game.kt:105).
+**Why it matters:** Edge-case bug. The arena's `maxPlayers` invariant can be violated by N-1 ms bursts of clicks. With N=24 a single tick of ~50ms can over-fill the game.
+**Suggested fix:** Add a capacity check inside `Game.addPlayer` (e.g., `require(_players.size < arena.maxPlayers) { "Game is full" }`) and have callers handle the exception or pre-check atomically. Better, gate the join through a single synchronized entry point on `Game`.
+**Confidence:** med
+
+### [SEV: med] gui/TeamSelectionMenu.kt:33-35 — `team.add(...)` return value ignored; "Joined" message sent even on full team
+**What:** `Team.add` (Team.kt:27) returns `false` if `isFull`, but `TeamSelectionMenu.open` ignores the return value and unconditionally sends `§aJoined Team ${team.id}!`. The player is not added (the mutation is rejected by the `if (isFull) return false`), but they get the success message and their inventory close fires.
+**Why it matters:** Logic bug. Players believe they joined a team when they did not. With 9 teams shown in a 9-slot GUI there's no way to know which team is full without clicking, and clicking on a full team leaves them confused.
+**Suggested fix:** Capture the boolean, send a different message on `false`, and ideally re-open the menu or refresh the icons. Also consider filtering the displayed teams to those with `!isFull`.
+**Confidence:** med
+
+### [SEV: med] gui/SpectatorMenu.kt:17-51 — Target list captured at open time; cross-world teleport not handled
+**What:** `open` iterates `game.alivePlayers` once and captures `Bukkit.getPlayer(gp.uuid)` and binds it in the click handler. If the target disconnects before the click, the teleport uses the player's last known `target.location` (which can be a world that has since been unloaded, leading to silent teleport failure or a teleport-into-void). The `spectator.teleport(target.location)` does not check `target.world == spectator.world`, so cross-world teleports may be rejected by Bukkit or land the spectator in a totally different map.
+**Why it matters:** Edge-case bug. Spectator UX is broken for the common "target died/went to lobby while menu was open" case and for "target teleported to arena hub."
+**Suggested fix:** Re-resolve `Bukkit.getPlayer(gp.uuid)` at click time; if the player is offline or in a different world, send a friendly message and do nothing. Optionally, gate by `target.world == spectator.world` before teleporting.
+**Confidence:** med
+
+============================================================
+LOW
+============================================================
+
+### [SEV: low] listeners/CustomItemListener.kt:40-71 — Cooldown is per-player, not per custom item
+**What:** `cooldowns` is `ConcurrentHashMap<UUID, Long>` and the only key is the player UUID. Using any custom item sets the cooldown for every other custom item. The 1-second window is enough to make a player feel "stuck" if they rapidly switch between a Fire Bomb and a regular custom item in the same hand.
+**Why it matters:** Minor design flaw. Not a security or data issue, but the cooldown does not match its apparent purpose.
+**Suggested fix:** Key the cooldown by the `CustomItem` key (e.g., `NamespacedKey`) so each item has its own timer. Use `cooldowns.compute(...)` or a `Map<NamespacedKey, Long>` nested under the player UUID.
+**Confidence:** med
+
+### [SEV: low] listeners/ChestListener.kt:38 — Unused `MiniMessage` field
+**What:** `private val mm = MiniMessage.miniMessage()` is declared and initialized but never read. Dead field.
+**Why it matters:** Style/quality.
+**Suggested fix:** Remove the field and the import.
+**Confidence:** high
+
+### [SEV: low] listeners/ChestListener.kt:154-163 — `scheduleRefill` task is not tracked or cancelled on plugin/game teardown
+**What:** `runTaskLater(...)` returns a `BukkitTask` whose handle is dropped on the floor. If the game ends (scope cancellation, server shutdown, `cleanup`) within `refillTimeSeconds`, the task still fires later and calls `filledChests.clear()` and `game.broadcastRefillMessage()` on a game whose scope is dead. The clear itself is harmless, but the broadcast is a no-op against a torn-down state and can spam logs / confuse any plugin hooking broadcasts.
+**Why it matters:** Defensive-coding nit. The leak doesn't break the feature, but it makes the listener fragile against server reloads and rapid game restarts.
+**Suggested fix:** Store the `BukkitTask` in a per-game or per-listener map and cancel it in `@PreDestroy` and in `Game.cleanup()`. Or schedule via `game.scope.launch { delay(...); withContext(bukkitDispatcher) { ... } }` so the task is cancelled automatically when the game scope dies.
+**Confidence:** med
+
+### [SEV: low] listeners/AdminWandListener.kt:38-40 — `beamTasks` values are mutable `MutableList` not protected for concurrent access
+**What:** `ConcurrentHashMap<UUID, MutableList<BukkitTask>>` is concurrent on the map, but `MutableList` itself is not. `showSpawnBeams` mutates the list (lines 169-176) and `hideBeams` iterates and removes it (line 180-182). Today both are called from the Bukkit main thread (events and `setSelectedArena`), so this is single-threaded in practice. The use of `ConcurrentHashMap` invites future contributors to call into this from off-thread code.
+**Why it matters:** Defensive-coding nit. Latent footgun for future refactors.
+**Suggested fix:** Either remove the `ConcurrentHashMap` (if everything stays main-thread) and document it, or wrap the values in a thread-safe structure (`CopyOnWriteArrayList` or a `synchronized` block).
+**Confidence:** low
+
+### [SEV: low] gui/ArenaSelectionMenu.kt:22-67 — `getAllActiveGames()` is scanned per arena to find the active game
+**What:** The map call is `getAllActiveGames().firstOrNull { it.arena.name == arena.name }`, which is O(arenas × games) per menu open. With dozens of arenas and concurrent games this becomes a non-trivial allocation on every GUI open. The team is also bucketing by name equality but `ArenaService.getArena(name)` is case-insensitive (`name.lowercase()`) while `arena.name` in `getGameByArena` is also lowercased (GameManager.kt:82), so this happens to work — but the case-sensitivity contract is implicit and easy to break.
+**Why it matters:** Performance / readability nit, not a correctness bug.
+**Suggested fix:** Build a `Map<arenaName, Game>` once before the loop (e.g., `getAllActiveGames().associateBy { it.arena.name }`) and look up by key. Add a `findGameInArena(arenaName)` to `GameManager` so the equality rule lives in one place.
+**Confidence:** med
+
+### [SEV: low] commands/SGCommand.kt:203-226 — `/sg start` doesn't validate arena enabled or world loaded
+**What:** `start` resolves the arena, refuses to start if a game already exists, then calls `createGame`. It does not check `arena.enabled` (used by `ArenaService.getAvailableArenas`) nor that `arena.worldName` is currently loaded. Starting a game whose world is not loaded leaves `arena.center.toBukkit()` returning null and silently falls back to the player's location.
+**Why it matters:** Minor. A disabled arena can be started; an arena in an unloaded world lands the game at a useless location. Both are operator errors, but the command should at least warn.
+**Suggested fix:** Check `arena.enabled` and `Bukkit.getWorld(arena.worldName) != null`; fail with a clear message.
+**Confidence:** low
+
+### [SEV: low] commands/SGCommand.kt:245-273 — `addplayer` produces a malformed error if `currentGame` is null
+**What:** After checking `isPlayerInGame`, the error message string-interpolates `currentGame?.arena?.name`, which is `null` if the lookup returned null (a theoretical race between the two queries). The player sees `arena 'null'`.
+**Why it matters:** Cosmetic. Indicates a small TOCTOU between `isPlayerInGame` and `getGameForPlayer`.
+**Suggested fix:** Either re-check after re-fetching, or use `currentGame?.arena?.name ?: "<unknown>"` so the message stays sensible.
+**Confidence:** low
+
+============================================================
+TEST-COVERAGE GAPS
+============================================================
+
+### [SEV: med] (Test gap) — No tests exist for any of the 14 files in this batch
+**What:** `src/test/kotlin/...` contains no `*CommandTest`, `*ListenerTest`, `*MenuTest`, `*GuiTest`, or `*ServiceTest` for the GUI, command, or listener layer. All 14 files in this batch have zero direct unit or integration coverage. A grep across `src/test` for `SGCommand`, `AdminWand`, `ChestListener`, `PlayerListener`, `CustomItemListener`, `FishingListener`, `GameBrowser` returns 0 matches.
+**Why it matters:** Several of the findings above (mid-game join, friendly-fire bypass, toBlockKey collisions, async create) are exactly the kind of behaviour that is easy to test in isolation with MockBukkit or paper-mock, and impossible to catch reliably in production.
+**Suggested fix:** Add at minimum:
+- `GameBrowserMenuTest` — clicking a game in Active/Deathmatch must reject; clicking a full game must reject.
+- `AdminWandListenerTest` — left-click adds a spawn, right-click sets center, persistence is verifiable.
+- `ChestListenerTest` — `toBlockKey` is bijective for plausible Y range; cross-arena fill does not occur; phase gating in `onChunkLoad` works.
+- `CustomItemListenerTest` — bomb damage respects `friendlyFire`, respects `isPvpEnabled` / `GamePhase`; poison bomb likewise; cooldown is per-item.
+- `PlayerListenerTest` — death during scope cancellation does not lose kill rewards; respawn sets spectator synchronously; eliminated players do not count toward damage stats.
+- `SGCommandTest` — `forcestart` actually changes phase; `create` is main-thread safe; race between `isPlayerInGame` and `addPlayer` is rejected.
+- `SpectatorMenuTest`, `TeamSelectionMenuTest`, `LeaderboardMenuTest`, `FishingListenerTest` — basic open/click and edge cases (offline target, full team, missing config).
+**Confidence:** high
+
+============================================================
+END OF REPORT
+============================================================

--- a/docs/audit/audit-hooks-misc.md
+++ b/docs/audit/audit-hooks-misc.md
@@ -1,0 +1,312 @@
+# Audit Report: audit-hooks-misc
+
+Batch 6 covers 14 files: `debug/DummyManager.kt`, `discord/DiscordService.kt`, `discord/GameEmbed.kt`, `hooks/{HookManager, LumaGuildsHook, NexoHook, PlaceholderAPIHook, PluginHook}.kt`, `util/cache/{ConcurrentChestFiller, GuiComponentCache, LootTableCache, PlayerDataCache, ScoreboardCache}.kt`, and root `LumaSGPlugin.kt`.
+
+Focus areas per brief: hooks lifecycle, async/threading (Bukkit main-thread rules), secret-leakage surface (Discord token, configs), and cache correctness.
+
+## Summary
+
+| Severity | Count |
+|----------|-------|
+| critical | 0 |
+| high     | 3 |
+| medium   | 6 |
+| low      | 8 |
+
+The biggest problems are concentrated in `PlayerDataCache.kt` (Bukkit main-thread violations in async Caffeine loaders and a DB-failure path that permanently serves zeroed stats). The hooks themselves are clean; Discord integration is structurally fine but has one startup-blocking call worth knowing about.
+
+No test sources exist anywhere in the repository, so every "test-coverage gap" listed below corresponds to currently-uncovered behavior. The audit calls out only the highest-value missing tests; trivial helpers are omitted.
+
+---
+
+### [SEV: high] util/cache/PlayerDataCache.kt:199 — `loadPermissionFromBukkit` runs Bukkit API on a Caffeine worker thread
+
+**What:** `permissionCache` is a `LoadingCache` whose loader is `::loadPermissionFromBukkit`. `Caffeine.newBuilder()...build(...)` defaults to the common `ForkJoinPool` executor. The loader calls `plugin.server.getPlayer(uuid)` and `player.hasPermission(permission)` — both of which are main-thread-only in Paper. There is no `withContext(bukkitDispatcher)` wrap.
+
+**Why it matters:** First permission check for any `(playerUUID, permNode)` pair will throw `IllegalStateException: ... not on main thread` (or read torn state) on Paper. The exception is swallowed at line 205–207 and the cache stores `false`, so the player is silently treated as lacking the permission. Cache then serves `false` for up to 10 minutes. Worst-case observable bug: a freshly-joined admin is treated as a regular player for ~10 min on their first permission miss.
+
+**Suggested fix:** Wrap the body in `withContext(bukkitDispatcher) { ... }` (injected as a constructor dependency — the `bukkitDispatcher` is already a Nexus bean) and change the cache to `LoadingCache<String, CompletableFuture<Boolean>>`, or precompute the result from a join event and `put` it.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] util/cache/PlayerDataCache.kt:106 — `getCachedDisplayName` reads Bukkit state on `ForkJoinPool.commonPool()`
+
+**What:** `getCachedDisplayName` does `CompletableFuture.supplyAsync({ val player = plugin.server.getPlayer(uuid) ... }, executor)` where `executor` is `ForkJoinPool.commonPool()`. `Bukkit.getPlayer` is main-thread-only.
+
+**Why it matters:** The first time a display name is requested for a UUID not in the cache (e.g., a leaderboard entry), the call violates the Bukkit main-thread contract. On strict Paper builds this throws; on lenient builds it returns null, and the code falls through to `getOfflinePlayer`, silently bypassing the cache. The result is then `put` into the cache, so the wrong/stale name gets pinned for 30 min.
+
+**Suggested fix:** Do `Bukkit.getPlayer` / `getOfflinePlayer` inside `withContext(bukkitDispatcher) { ... }` and complete the future from the coroutine, or move the load to a join event handler that runs on the main thread.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] util/cache/PlayerDataCache.kt:74 — DB failure permanently caches zeroed-out `PlayerStats`
+
+**What:** `getCachedStats` has:
+```kotlin
+statsCache.get(uuid).exceptionally { throwable ->
+    logger.warn("Failed to load stats for UUID: {}", uuid, throwable)
+    PlayerStats(uuid = uuid, playerName = "Unknown Player")
+}
+```
+Because `Caffeine.AsyncLoadingCache` calls the loader via `buildAsync { ... nexusScope.future { ... } }`, an exception is converted into a failed future. The `.exceptionally` here returns a *sentinel default* `PlayerStats` — but the AsyncLoadingCache does not store the exceptionally-provided value; it propagates the failure upstream. **However**, callers that chain another `.exceptionally` / `.get()` will see the default. More importantly, on the next access the loader runs again; if the DB is still down, the same `PlayerStats(uuid, "Unknown Player")` (all zeros) is the only thing the placeholder code path produces. A user-visible regression: a player who plays one game, then the DB hiccups, sees `kills=0, deaths=0, wins=0` in placeholders and scoreboards for up to 30 minutes (`expireAfterWrite`) — and stat placeholders that return "0" by design in `PlaceholderAPIHook.kt:31` will then look like a stat reset.
+
+**Why it matters:** Misleading stats for an entire player base during a transient DB outage; if the DB then recovers the same data is re-fetched, but during the window placeholders and Discord announcements broadcast zeros. Worse, the `Unknown Player` name leaks into every downstream display (embed author, leaderboard row) — visible to all players, not just the affected one.
+
+**Suggested fix:** On loader failure, return a `PlayerStats` with a sentinel marker (e.g., `playerName = null`) and have the cache layer treat it as "not loaded" / "stale"; or just let the exception propagate and let the caller decide. Do not put the failure default into a path that writes to log + returns a value that looks like a real player record.
+
+**Confidence:** med (the exact Caffeine behavior for AsyncLoadingCache + `exceptionally` returning a value is subtle; the visible-to-players zero-stats symptom is what matters and is high-confidence).
+
+---
+
+### [SEV: med] util/cache/LootTableCache.kt:103 — `preGenerateLootTables()` is never invoked at startup
+
+**What:** The method is defined and called only from `forceRegeneration` (line 149). There is no call site in `LumaSGPlugin.onEnable`, no `@PostConstruct` call, and no scheduled task that does an initial pre-gen. The `@PostConstruct init()` only schedules the 15-min regeneration, which only fires on buckets that already have data (it only regenerates if `existing.size < PREGENERATED_CHESTS_PER_TIER / 2`).
+
+**Why it matters:** First game of a server boot pays the full on-demand generation cost. The first `getPreGeneratedChest` call for each (tier, mode) pair triggers `generateLootTableForTier` on the calling thread (line 133), blocking game-start. With ~50 chests per bucket × N tiers × 2 modes, this can stall `preGame` for seconds. `ConcurrentChestFiller` is the hot consumer; its `fillChestsForGame` would otherwise have benefited from a warm cache.
+
+**Suggested fix:** Call `preGenerateLootTables()` from `LumaSGPlugin.onEnable` after the arena service is ready, or from a `@PostConstruct` of a service that runs late in the init chain. Or change the 15-min task to always run the first iteration immediately.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] hooks/LumaGuildsHook.kt:40 — HIGHEST-priority `un-cancel` may lose the race against LumaGuilds itself
+
+**What:** The handler runs at `EventPriority.HIGHEST` to set `event.isCancelled = false` after LumaGuilds' `CombatService` has cancelled same-guild damage. Per Bukkit docs, ordering between two handlers at the same priority is *undefined*. If LumaGuilds' own `EntityDamageByEntityEvent` listener also runs at `HIGHEST` (or `HIGH`/`HIGHEST` and the dispatcher orders them differently across server versions), the final cancellation state depends on JVM internal listener ordering — not contractually guaranteed.
+
+**Why it matters:** Edge case where PvP between guild members during Deathmatch silently fails to deal damage — players would think they hit but take no damage, and the survival-game elimination logic never fires for that interaction. No log, no warning.
+
+**Suggested fix:** Either (a) negotiate a softer integration with LumaGuilds (e.g., a public API hook), or (b) on the SG side run the un-cancel at `MONITOR` and rely on the documented guarantee that MONITOR is the last to run for the event, *and* add an explicit assertion that `event.isCancelled` was true at entry to detect the case where LumaGuilds didn't actually cancel.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] discord/DiscordService.kt:32 — `awaitReady()` blocks the server's main thread during `onEnable`
+
+**What:** `JDABuilder.createLight(...).build().awaitReady()` is a blocking call. It runs in the `@PostConstruct` of a service constructed during `LumaSGPlugin.onEnable` (line 27–36), which itself runs on the server's main thread. `awaitReady` waits for the JDA gateway handshake, which can take several seconds on a slow connection and is documented to throw on auth failure only after a timeout.
+
+**Why it matters:** Cold start of a server with a slow/flaky Discord endpoint (or a valid token but unreachable Discord API) can stall the entire server enable for the full JDA timeout (configurable, default ~10s, but can be longer with a `LoginException` causing a retry). Players and other plugins see no progress.
+
+**Suggested fix:** Build JDA without `awaitReady()` (the builder returns immediately), and either use `jda.awaitReady().onSuccess { ... }` (coroutine) or schedule the announce check to defer until `JDA.Status` is `CONNECTED`. The `announce`/`postStats` already guard `jda?.getTextChannelById(...)` against a null JDA, so dropping the `awaitReady` is safe.
+
+**Confidence:** med (depends on whether Nexus @PostConstruct is invoked on the main thread — by the visible code path it is, because `NexusContext.create` is called synchronously from `onEnable`).
+
+---
+
+### [SEV: med] util/cache/PlayerDataCache.kt:54 — Permission cache is stale for up to 10 min after grants/revokes
+
+**What:** `permissionCache` has `expireAfterWrite(10m)` and `expireAfterAccess(5m)`. There is no event-based invalidation when a player's permissions change at runtime (e.g., LuckPerms `PermissionUpdateEvent`, or `/lp user ... permission set`). The only invalidation is `invalidatePlayer(uuid)` on player leave, which doesn't help for an *online* player whose permissions just changed.
+
+**Why it matters:** A moderator who gets `lumasg.moderator` granted mid-session will not see permission-gated commands/placeholders work for up to 10 min. A player whose `lumasg.vip` is revoked will continue to see VIP-only features in the GUI cache for the same window.
+
+**Suggested fix:** Add a `Listener` that hooks LuckPerms `PermissionUpdateEvent` and calls `invalidatePlayer` or `permissionCache.invalidate("$uuid:$node")`. At minimum, expose an `invalidatePermission(uuid, node)` and document that callers must invoke it.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] util/cache/LootTableCache.kt:132 — Double generation on concurrent cache miss
+
+**What:** `getPreGeneratedChest`:
+```kotlin
+var chests = lootTableCache.getIfPresent(key)
+if (chests.isNullOrEmpty()) {
+    generateLootTableForTier(tier, mode)
+    chests = lootTableCache.getIfPresent(key)
+    ...
+}
+```
+Two callers that miss concurrently both run `generateLootTableForTier`. The second call overwrites the first bucket and resets the round-robin `AtomicInteger` to 0 (line 234). The wasted CPU is non-trivial — 50 chests × N items each, all on the calling thread.
+
+**Why it matters:** At server start, when many chests are being filled in parallel (e.g., `ConcurrentChestFiller.fillChestsForGame` fans out per chest), the very first batch will all hit the cold cache and trigger redundant `generateLootTableForTier` calls. If the game-start path is already async, this stacks. Combine with the missing startup pre-gen (see prior finding) and the first game of the day pays this cost N times.
+
+**Suggested fix:** Use `Caffeine.build(key, mappingFunction)` with a `CacheLoader` and Caffeine's `getAll`/`get` will dedupe. Or wrap the generate step in `putIfAbsent` semantics on a separate `ConcurrentHashMap<CacheKey, CompletableFuture<...>>` and `.join()` from the loader.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] util/cache/ConcurrentChestFiller.kt:86 — `chest.location` accessed on possibly off-main thread in error path
+
+**What:** Inside `fillChestFromCache`, the `try` block contains `withContext(bukkitDispatcher) { ... }`. The `catch (e: Exception)` block (line 85–88) runs `logger.error("Error filling chest at {} ...", chest.location, tier, e)` on the *calling* coroutine context, not the main thread. `chest.location` (`BlockState.getLocation()`) is main-thread-only on Paper. The same pattern exists in `fillChestSync` (line 109) — there the method is documented as main-thread-only so it is only a concern if a future caller violates the contract.
+
+**Why it matters:** A failure during chest fill will throw a second exception from the error log itself on strict Paper builds, masking the original failure and producing unhelpful stack traces.
+
+**Suggested fix:** Move the log line inside the `withContext(bukkitDispatcher)` block (capture `chest.location` on the main thread), or use `Location.toString()` outside (which itself calls into Bukkit — same problem). Cleanest: log just the tier and chest coordinates captured before the failing call.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] debug/DummyManager.kt:82 — Linear scan over `getAllActiveGames()` on every dummy death
+
+**What:** `gameManager.getAllActiveGames().firstOrNull { it.id == gameId }` is O(n) per dummy death. If multiple solo games are running in parallel (e.g., admins stress-testing), each dummy death scans the full list.
+
+**Why it matters:** Debug-only code path, but EventHandler listeners run on the main thread; a hot path that scales O(N) with active games on the main thread is a stutter risk during large test setups.
+
+**Suggested fix:** Add a `Map<UUID, Game>` lookup on `GameManager` (one already exists at `activeGames`), or have `DummyManager` cache `villager.uniqueId → game` directly (which it does on line 70) and dereference the Game from there instead of going through `gameManager`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] debug/DummyManager.kt:55 — Comment doesn't match behavior of `drop(game.players.size)`
+
+**What:** Comment says "Skip index 0 so the real player keeps their spawn" but the code skips `game.players.size` entries. It works only because the calling `debugDummies` command (SGCommand.kt:532–534) calls `addPlayer` before invoking `spawnDummies`, leaving `players.size == 1` at that point. If the call order ever changes, dummies collide with the real player's spawn.
+
+**Why it matters:** Latent bug. Today the assumption holds, but a future refactor of the command (e.g., spawning dummies into a not-yet-started game with multiple real players already queued) would silently misalign spawns.
+
+**Suggested fix:** Either fix the code to match the comment (`drop(1)`) or fix the comment and add a precondition check that `players.isNotEmpty() && players.values.first()` is the real player. Alternatively, pass the player's spawn index explicitly.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] debug/DummyManager.kt:86 — Dummy-on-dummy kill still broadcasts "eliminated by Dummy_X"
+
+**What:** `entity.killer` may be another villager (a dummy). The branch at line 95–101 will then broadcast `"<Dummy_A> was eliminated by <Dummy_B>!"`. The kill-counter increment at line 88 is a no-op (the killer UUID isn't a `GamePlayer`), so the broadcast is the only observable artifact.
+
+**Why it matters:** Cosmetic. Debug only.
+
+**Suggested fix:** Gate the broadcast on `killer is Player`, or treat villager-on-villager kills as a no-op for broadcast purposes.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] hooks/PlaceholderAPIHook.kt:48 — `PlaceholderExpansion` is never unregistered
+
+**What:** `.register()` is called in `@PostConstruct`, but the class has no `@PreDestroy` to call `PlaceholderExpansion.unregister()`. On `/plugman reload` or a hot-reload, the expansion is still registered in PlaceholderAPI but bound to the previous classloader. The next reload piles up.
+
+**Why it matters:** Classloader leak / stale-expansion after a reload. Production servers typically don't reload, so impact is low.
+
+**Suggested fix:** Hold the expansion reference and call `unregister()` from a `@PreDestroy`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] hooks/LumaGuildsHook.kt:30 — Event listener is never unregistered
+
+**What:** `registerEvents(this, plugin)` is called in `@PostConstruct`, but no corresponding `unregisterEvents(this)` in `@PreDestroy`. A plugin reload leaks the listener registration.
+
+**Why it matters:** Same pattern as PlaceholderAPIHook. Mostly impacts reload workflows.
+
+**Suggested fix:** Add a `@PreDestroy` that calls `HandlerList.unregisterAll(this)`.
+
+**Confidence:** high
+
+---
+
+### [SEV: low] discord/DiscordService.kt:49 — `try/catch` around `queue()` doesn't catch the failure path
+
+**What:**
+```kotlin
+nexusScope.launch {
+    try {
+        channel.sendMessageEmbeds(embed).queue()
+    } catch (e: Exception) {
+        logger.warn("Failed to send Discord announcement: ${e.message}")
+    }
+}
+```
+JDA's `queue()` returns immediately and dispatches to its own thread pool; failures are reported through the success/failure callbacks (`queue(Consumer, Consumer)`), not via thrown exceptions from the call site. The `try/catch` only catches the rare synchronous failure (e.g., channel null after a re-fetch).
+
+**Why it matters:** Misleading error handling: a real Discord send failure (rate-limit, missing perms, gateway down) is logged silently by JDA and not visible in the LumaSG log. Operators see a working integration that actually isn't delivering.
+
+**Suggested fix:** Use the overload `queue(Consumer<RestAction<T>> onSuccess, Consumer<Throwable> onFailure)` and route `onFailure` to `logger.warn("Failed to send ...", it)`.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] LumaSGPlugin.kt:65 — `runBlocking { ... saveAll() }` on the shutdown thread
+
+**What:** `onDisable` blocks the shutdown thread on the arena persistence save. If `ArenaService.saveAll` writes many arenas or talks to a slow JDBC store, the server appears hung during shutdown.
+
+**Why it matters:** Operator-facing delay. Not a correctness bug, but the shutdown-time blocking pattern is worth knowing.
+
+**Suggested fix:** Use the plugin's existing coroutine scope with a bounded timeout, or schedule `saveAll` at the end of each game so `onDisable` only flushes the in-memory delta.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] util/cache/LootTableCache.kt:251 — No defense against misconfigured `minAmount`/`maxAmount`
+
+**What:**
+```kotlin
+stack.amount = if (selected.maxAmount > selected.minAmount) {
+    selected.minAmount + random.nextInt(selected.maxAmount - selected.minAmount + 1)
+} else {
+    selected.minAmount
+}
+```
+If `minAmount` is `0` or negative, the fall-through path produces an empty or invalid stack. If `minAmount > maxAmount` (config typo), the fall-through is taken, but the value is still `minAmount` (not what the operator wrote in `maxAmount`).
+
+**Why it matters:** A single misconfigured item in `chest-items.yml` produces a silent silent-fail (empty stack in chest) that no log line points to. Operator sees a chest that "looks right" but contains a no-op slot.
+
+**Suggested fix:** Clamp `stack.amount` to `[1, maxStackSize]`, log a warning when the input is out of range, and treat `minAmount < 1` as a config error.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] util/cache/ScoreboardCache.kt:120 — Fuzzy `startsWith` key match on player UUIDs
+
+**What:** `invalidatePlayer` does `scoreboardLineCache.asMap().keys.removeIf { it.startsWith(playerPrefix) }` and the same for `placeholderCache`. The prefix is a full UUID string, but the line/placeholder caches have keys like `"$gameId:$lineType:$value"` and arbitrary user-supplied strings, so collision is unlikely. Still, `startsWith` on a fixed-length prefix is correct in practice only because the `:` separator in those cache keys prevents ambiguity.
+
+**Why it matters:** If a future caller adds a cache key that *legitimately* starts with a UUID string (e.g., `"$uuid:nickname"`), `invalidatePlayer` will wipe it even though the entry is global rather than per-player.
+
+**Suggested fix:** Require the separator in the predicate: `it.startsWith("$playerPrefix:")` or wrap a structured key in a data class.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] util/cache/GuiComponentCache.kt:181 — `createGuiItem` parses up to 3 colon-segments but only uses first 2
+
+**What:** `parts.split(":", limit = 3)` produces up to 3 parts, then `parts[0]` and `parts[1]` are consumed. The third part is silently dropped. Keys like `"button:back:12345"` work because `parts[1] = "back"` and the loader doesn't care about `parts[2]`.
+
+**Why it matters:** Cache key design is incoherent. The hashed display name (line 99) and stat-value hash (line 115) influence cache *lookup* but not the constructed item. This is fine semantically (the value is the same) but means the cache is *less effective* than the keys suggest: a `SimpleItem` is built from `buttonType` only, so every call with the same `buttonType` should share a cache entry but instead gets a separate one per `(buttonType, displayName)` pair.
+
+**Suggested fix:** Make the cache key match the value: drop the hash, use `"button:$buttonType"`. Then the supplier fast-path (line 102) and the loader fast-path (line 104) hit the same entry.
+
+**Confidence:** med
+
+---
+
+## Test-coverage gaps (project has no test sources at all)
+
+The repository has zero test files. The following behaviors are particularly worth covering before the affected code is refactored again:
+
+- **util/cache/LootTableCache.kt:264** — `weightedRandomItem` weight math, including the `totalWeight <= 0` fallback branch. The deterministic test would feed a known `(tier, mode)` and assert distribution.
+- **util/cache/PlayerDataCache.kt:75** — the DB-failure path in `getCachedStats`. A mock repository that throws on `findByUuid` should verify what the *caller* receives (not what the loader returns).
+- **hooks/LumaGuildsHook.kt:40** — the un-cancel logic for two players in the same game during `Active`/`Deathmatch` versus `Grace`/`Waiting`, and the same-team carve-out.
+- **util/cache/ConcurrentChestFiller.kt:99** — the `fillChestSync` synchronous path that was added specifically to close the "player opens empty chest" race. There should be a test that pre-fills the cache, calls `fillChestSync` from a non-coroutine context, and asserts the chest is populated *before* the call returns.
+- **util/cache/ScoreboardCache.kt:64** — `PlayerScoreboardData.needsRefresh(interval)` returns true on the very first call regardless of `lastUpdate = 0L`. The contract should be specified and pinned.
+- **discord/GameEmbed.kt** — trivial; not worth a test.
+
+---
+
+## Files with no findings
+
+- `hooks/HookManager.kt` — straight delegation; correctness depends on `getGameForPlayer` and `isPvpEnabled` (in `game/` package, not in this batch).
+- `hooks/PluginHook.kt` — single-line default; fine.
+- `hooks/NexoHook.kt` — defensive `try/catch` around `NexoItems.itemFromId(id)?.build()`. `id` is supplied by trusted internal callers (config), no NBT injection surface here.
+- `discord/GameEmbed.kt` — pure data builder, no findings.
+- `debug/DummyManager.kt` — only low-severity findings (see above).
+- `util/cache/GuiComponentCache.kt` — one low finding (incoherent cache key); no correctness bug.
+
+---
+
+## Notes for the next pass
+
+- `DummyManager.spawnDummies` and the dummy-villager `eliminate` flow both need to live with the `Game.addDummy` shape. If `GamePlayer` ever gains a `Player` reference (it currently does not — confirmed at `GamePlayer.kt`), dummies would need to be excluded. Worth a comment in `Game.kt:101`.
+- The Discord token (`config.discord.botToken`) is not logged anywhere; the only place it could leak is via a JDA exception message. JDA's `LoginException` / `InvalidTokenException` messages do not embed the token, so this batch is clean on secret-leakage. If a future change logs `JDAException` objects directly, that would re-open the issue.
+- The hooks are correctly idempotent on the not-present path (`isAvailable()` short-circuit before any class loading). No `ClassNotFoundException` risk.

--- a/docs/audit/audit-items.md
+++ b/docs/audit/audit-items.md
@@ -1,0 +1,570 @@
+# Audit Report: audit-items
+
+Scope: `src/main/kotlin/net/lumalyte/lumasg/chest/ChestItem.kt`,
+`chest/ChestManager.kt`, and `items/{AirdropFlareItem,AirstrikeItem,BombItem,CustomItem,CustomItemsManager,FireBombItem,GliderItem,KnockbackStickItem,PlayerTrackerItem,PoisonBombItem,SmokeGrenadeItem}.kt` (13 files).
+Focus: dupe-exploits, main-thread/Bukkit-API violations, race conditions, NBT/serialization safety, test coverage.
+
+Existing test coverage in this surface area: zero. The test tree has only
+`persistence/`, `game/`, `domain/` subpackages — no tests exercise any
+custom item, the chest manager, or `CustomItemsManager` despite the code
+running 9 distinct items with stateful listeners and shared coroutine
+timers.
+
+---
+
+### [SEV: high] chest/ChestManager.kt:154-204 — `fillChest` only fills one half of a double chest, leaving orphaned loot
+
+**What:** `fillChest` reads `state` (one half of a `Chest` block) and calls
+`state.inventory.clear()` followed by `inventory.setItem(...)` on a single
+`Inventory` (size 27 for a single chest, 54 for a double). The companion
+half of a double chest is never cleared, and items previously placed in
+the other half are not re-randomised or synchronised.
+
+**Why it matters:** In an arena with double chests (common in SG maps), a
+player opening the chest sees 27 fresh items on one side and whatever
+items were in the other half (from a previous refill, a chunk-load fill
+that used the *other* half as the entry-point `state`, or admin-placed
+loot). It is also reachable in a real dupe path: a `ChunkLoadEvent`
+firing while a double chest is split across a chunk boundary can fill
+each half independently, and if `filledChests` is cleared on refill
+(ChestListener:159) the next pass can re-fill both halves with newly
+generated loot while the old loot from the unfilled half is still
+present in tile-entity state.
+
+**Suggested fix:** Detect double-chests via `state.inventory.holder` and
+when the other half is a `Chest`, operate on the merged inventory. The
+`org.bukkit.block.Chest` API exposes `getInventory()` returning the
+merged double-chest view; use `((DoubleChestInventory) inv).getHolder()`
+or, more reliably, loop both halves via `state.getOtherHalf()` and
+`state` and clear/set both inventories. For double-chests, allocate from
+the *full* merged 54-slot inventory, not the 27-slot half view.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] items/CustomItemsManager.kt:99-104 — `reload()` re-registers Bukkit listeners without unregistering, causing duplicate event handling
+
+**What:** `reload()` calls `shutdownItems()` (which only stops BukkitRunnables
+and clears state — does not unregister listeners), then `registry.clear()`,
+then `registerDefaults()`. The `registerDefaults` body (lines 50-54) calls
+`item.register()` for `GliderItem`, `SmokeGrenadeItem`, and
+`AirstrikeItem`. Each `register()` calls
+`plugin.server.pluginManager.registerEvents(this, plugin)`. Bukkit allows
+the same Listener instance to be registered multiple times; every event
+subsequently invokes the handler twice.
+
+**Why it matters:** After a `/sg reload` (or any path that hits `reload()`),
+the airstrike / glider / smoke-grenade handlers run twice. For
+`AirstrikeItem`, the charge state-machine is idempotent (guarded by
+`chargeStates.containsKey`), but `onDrop`, `onItemHeld`, `onQuit` and
+`onDamage` each emit `cancelCharge` / `cancelGlide` redundantly — cheap,
+but the PlayerTrackerItem-style `updateTask` is started in `register()`
+without being stopped first, so the periodic compass update fires twice
+per tick after reload (double CPU, double `sendActionBar` calls, the
+client sees the second write win). For GliderItem, the `glideTask` is
+similarly restarted without cancelling, doubling particle/sound work
+and potentially confusing the `state.glidingActive` flag.
+
+**Suggested fix:** Either (a) make `register()` idempotent via a
+`@Volatile var registered = false` guard around the
+`registerEvents` call, or (b) in `shutdownItems`, also call
+`HandlerList.unregisterAll(this)` for the Listener items, or (c) drop
+the manual `register()` calls from `registerDefaults` and instead
+expose the items as DI services so the framework only registers them
+once.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] items/AirstrikeItem.kt:293-298 — airstrike immune-list logic makes the caller the only team member who can take damage
+
+**What:** Inside the per-meteor `onImpact` lambda:
+```kotlin
+val immuneUUIDs = mutableSetOf<UUID>()
+val callerTeam = game.teamManager.getTeamForPlayer(callerUuid)
+if (callerTeam != null) {
+    immuneUUIDs.addAll(callerTeam.members)
+}
+immuneUUIDs.remove(callerUuid)
+```
+The team (which contains the caller) is added to the immune set, then
+the caller is removed. Net effect: the caller's teammates are immune,
+the caller is not.
+
+**Why it matters:** The caller's *own* meteor kills them but spares
+their teammates. In a duo/trios/squads game this is a grief-vector: a
+player can drop an airstrike on a teammate (locked onto shared
+position) and the teammate takes zero damage while the caller is the
+only one punished — or, more commonly, in normal use the caller is
+penalised for an ability that was supposed to be team-safe. It is
+also the opposite of what the surrounding code (AirdropFlareItem
+explosion at line 100, which has *no* team immunity) suggests is the
+intended design.
+
+**Suggested fix:** Remove the `immuneUUIDs.remove(callerUuid)` line. If
+the design is "caller immune, team not," reverse the order: add caller
+to a base set, then add team members. Document the chosen policy.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] items/AirdropFlareItem.kt:99-108 — chest is placed inside the player or on top of an arbitrary block with no safety check
+
+**What:** `MeteorUtils.spawnExplosion(center = dropLocation, plugin = plugin)`
+runs first (line 100), which can damage the player. Then
+`findSolidGround(dropLocation)` (line 103) walks down from the player's
+*current* location — the player may have been pushed by the explosion
+or another player — and sets `chestLoc.block.type = Material.CHEST`
+(line 104) unconditionally. There is no check that the target block is
+air, that the location is within the arena, or that the chest location
+is not occupied by a player, mob, or block entity (e.g. another chest,
+sign, bed).
+
+**Why it matters:** Multiple game-breaking scenarios:
+1. If the player stands still and the impact location is the same as
+   the player location, `findSolidGround` descends to the floor under
+   the player and the chest is placed at floor+1 — directly under or
+   inside the player, suffocating or trapping them.
+2. The chest silently overwrites non-air blocks (a sign, a previously
+   placed chest, a redstone component). For non-vanilla tile entities
+   this destroys their contents with no log.
+3. The chest is placed at the player's *current* location, not the
+   flare-aimed location. If the player moves during the 5-second
+   indicator + 2-second pre-impact, the airdrop can end up nowhere
+   near where the flare was thrown.
+4. No null check on `findSolidGround` reaching the void — the function
+   stops at y=0 and places a chest at y=1 (floating in the air if no
+   solid block exists).
+
+**Suggested fix:** Capture the target location from the player's look
+direction (or from a snapshot at flare-use time, not at impact time).
+Before placing the chest, verify the block is air and that the
+resulting chest location is within the arena bounds. For occupied
+blocks, queue the chest placement to a clear neighbouring block or
+abort with a message. Snapshot the player location at `onUse` time
+instead of recomputing via `player.location.clone()` so the impact is
+predictable.
+
+**Confidence:** high
+
+---
+
+### [SEV: high] items/AirstrikeItem.kt:182-191 — held item decremented before game lookup, so charges can be lost to a no-op game resolution
+
+**What:** In `handleLocked`:
+```kotlin
+if (state.lockTicks >= cfg.lockOnDurationTicks) {
+    toRemove.add(uuid)
+    val held = player.inventory.itemInMainHand
+    if (isAirstrikeItem(held)) held.amount--
+    player.sendActionBar(Component.empty())
+    val game = gameManager.getGameForPlayer(uuid) ?: return
+    launchAirstrike(state.targetLocation, game, uuid, player.name)
+}
+```
+The item is decremented and the action bar cleared *before* the game
+lookup. If `getGameForPlayer` returns null (player left, game ended,
+race), the function `return`s without launching the strike. The
+charge-state is also already removed via `toRemove.add(uuid)`, so the
+item is consumed but no strike fires.
+
+**Why it matters:** A boundary-condition dupe: if a player holds the
+charge through the lock-on duration and then disconnects, reconnects,
+or has their game ended by an external event in the same tick, the
+airstrike item is consumed without any effect. The same window
+exists for `PlayerQuitEvent` racing the task — the `onQuit` handler
+calls `cancelCharge` which removes from `chargeStates`, but the task
+may have already advanced `lockTicks` past the threshold and executed
+the decrement. Charge is consumed, strike is never called.
+
+**Suggested fix:** Reorder: resolve the game first, then consume the
+item, then launch. Add a `if (game == null) return` early-out that
+preserves the charge state (i.e., don't add to `toRemove` until the
+launch is actually scheduled).
+
+**Confidence:** med
+
+---
+
+### [SEV: med] items/GliderItem.kt:216, 247-250 — `recentlyGliding` map grows unboundedly for offline players
+
+**What:** `recentlyGliding: ConcurrentHashMap<UUID, Long>` is populated
+on every glide end (line 154) and only cleaned up in `onQuit` (line
+249). Players who glide, land, and then take fall damage within the
+5-tick grace window are properly removed (line 231). But players who
+glide, land, and *never* take fall damage leave an entry that persists
+until they quit. The map also persists across server restarts in
+memory (it's a plain HashMap, not persisted — so it dies on restart,
+but accumulates within a single uptime).
+
+**Why it matters:** A long-uptime server with thousands of glider-uses
+accumulates UUID→fullTime entries. Not a critical memory leak (two
+Longs per entry ≈ 64 bytes), but it is unbounded. The `onQuit`
+handler is the only cleanup, and players who crash-disconnect without
+firing `PlayerQuitEvent` (rare, but possible during netty errors)
+leave permanent entries.
+
+**Suggested fix:** Cap the map (Caffeine cache with size limit and
+expiry), or evict entries older than the grace window (5 ticks)
+periodically. Alternatively, since the only consumer is the
+5-tick-window fall-damage check, drop the map entirely and use a
+`Set<UUID>` of "just-landed" players that is cleared by a delayed
+task.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] items/SmokeGrenadeItem.kt:173-203 — `updateVisibility` only iterates observer/target pairs within 3× the cloud radius
+
+**What:** `nearbyPlayers` is computed via `getNearbyEntities(center,
+checkRange, ...)` where `checkRange = radius * 3` (line 177). The
+double `for` loop (lines 182-183) iterates `for (observer in
+nearbyPlayers) for (target in nearbyPlayers)`. Targets that are in
+line-of-sight of the observer through the cloud but lie *outside*
+the 3× radius envelope (e.g. a target 50 blocks away behind a
+nearby cloud) are never considered — so they are never hidden even
+though the cloud is on the ray between them.
+
+**Why it matters:** The smoke grenade is described as "blocks vision
+and nametags", but this implementation only hides players who are
+themselves within the 3× radius of the cloud. Snipers, distant
+enemies, or anyone beyond `radius * 3` is unaffected regardless of
+whether the cloud is directly in their line of sight. This is a
+gameplay integrity failure — the item doesn't do what its lore
+promises, and players can infer the radius boundary and use it to
+their advantage.
+
+**Suggested fix:** Iterate all online players (or use a much larger
+search radius) as the candidate observer set, and for each observer
+check whether any active cloud blocks their line of sight to each
+target. Use the existing `rayIntersectsSphere` per (observer, target,
+cloud) — it's already O(c) per pair, just need a wider candidate
+set.
+
+**Confidence:** high
+
+---
+
+### [SEV: med] items/SmokeGrenadeItem.kt:264-273 — `restoreAllVisibility` unconditionally `showPlayer`s every hidden target, including those still legitimately hidden
+
+**What:** On `@PreDestroy shutdown`, `restoreAllVisibility` iterates
+`hiddenPlayers` and calls `observer.showPlayer(plugin, target)` for
+every entry. There is no `activeClouds.values.any { ... }` check
+(compare to `restoreVisibilityForCloud` line 251 which does have
+this check). If the plugin is reloaded or the server shuts down with
+active smoke clouds, all hidden targets are revealed, breaking the
+in-flight smoke screen.
+
+**Why it matters:** The intended behaviour on shutdown is debatable,
+but the asymmetry with `restoreVisibilityForCloud` (which respects
+other clouds) is a real bug. After a hot-reload, all smoke cover
+collapses instantly.
+
+**Suggested fix:** In `restoreAllVisibility`, mirror the
+`stillBlocked` check from `restoreVisibilityForCloud`: only
+`showPlayer` for entries where no other cloud still blocks the
+visibility.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] items/PlayerTrackerItem.kt:247-261 — top-killer calculation only counts online players, missing the actual leader during a disconnect
+
+**What:** `findTopKiller` returns the UUID of the player with the most
+kills among currently-online players in the game. A player with the
+leading kill count who briefly disconnects (network blip) is skipped
+entirely — the next-highest online killer is shown.
+
+**Why it matters:** The compass is the dominant information tool
+during late-game deathmatch. If the leading killer rage-quits at
+2 kills ahead, the compass points to the 2nd-place online player
+until the leader reconnects. This is a state desync between the
+real leader (GamePlayer.kills) and what the compass shows, and
+players can grief it by re-logging at strategic moments.
+
+**Suggested fix:** Don't filter by online status; base the top-killer
+purely on `gp.kills`. If the player is offline, the compass entry
+won't be drawn (because `Bukkit.getPlayer(uuid)` is null in the
+target loop), but the `isTopKiller` flag is already set on the
+correct UUID, so when they reconnect, the marker immediately
+attaches to the right target.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] items/AirstrikeItem.kt:110-142 — `chargeTask` self-cancels when `chargeStates` is empty but doesn't survive a single-tick exception
+
+**What:** `ensureTaskRunning` creates a BukkitRunnable. Inside `run()`,
+the first guard is `if (chargeStates.isEmpty()) { cancel();
+chargeTask = null; return }`. There is no try/catch around the body.
+If the loop body throws (e.g. from a Bukkit API call on a removed
+entity, an NPE in `handleCharging` when the player teleports
+mid-raycast, or a deserialise failure on a malicious config string),
+Bukkit catches the exception and logs it — but the task *continues
+running* on the next tick. `chargeTask` is still set, so the
+guard `if (chargeTask != null) return` blocks recreation. The task
+keeps ticking with stale state, but if the exception happened before
+`toRemove.forEach { chargeStates.remove(it) }`, a stuck state can
+leak.
+
+**Why it matters:** A single transient exception leaves the charge
+state machine running but non-functional. Players who right-click
+to start a new charge will hit `chargeStates.containsKey(player.uniqueId)`
+and silently no-op (the entry is still there from a previous
+aborted run). The fix is small and the impact is "charge
+occasionally deadlocks until restart" — not a dupe, but a
+playability issue.
+
+**Suggested fix:** Wrap the body in `try { ... } catch (e: Exception) {
+logger.error("Airstrike charge task failed", e); cancel(); chargeTask
+= null }`. Or use `runTaskTimer` with a coroutine wrapper and
+`runCatching`.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] items/SmokeGrenadeItem.kt:275-290 — `cleanupVisibility` Elvis fallback `continue` is correct but reads like a bug; also misses the target-set cleanup in the outer scope
+
+**What:** Lines 287-288:
+```kotlin
+if (set.remove(uuid)) {
+    val observer = Bukkit.getPlayer(observerUuid) ?: continue
+    observer.showPlayer(plugin, player ?: continue)
+}
+```
+The `?: continue` Elvis-fallback to `Nothing` is functionally
+correct, but the second `continue` is inside a `for` whose iteration
+variable is `set` (a per-observer set) — `continue` skips to the
+next `(observerUuid, set)` entry, not the inner `for (targetUuid in
+hidden)`. So if `player` is null, all remaining target UUIDs in
+`hiddenPlayers` are skipped, not just the current one. The
+correct `continue` target is unclear, suggesting the author wasn't
+sure.
+
+Also, `cleanupVisibility` is only called from `onQuit` (line 294).
+It cleans up the quitting player's own hidden set and their
+appearances in other observers' sets, but it does *not* remove
+references to the quitting player from the `target` side of
+`activeClouds` (clouds don't hold target references, so this is
+fine — but the inner `for` on line 284-289 iterates
+`hiddenPlayers.entries`, which is fine).
+
+**Why it matters:** The Elvis-`continue` issue means that if the
+quitting player object is `null` (server has already removed the
+Player reference), the entire `hiddenPlayers` cleanup loop
+short-circuits and other observers are left with stale `hidden`
+entries. After several quit-while-in-smoke events, observers can
+accumulate hidden-by-UUID entries that block legitimate
+`showPlayer` calls (Bukkit silently no-ops on showPlayer for
+unknown UUIDs, but the bookkeeping drifts).
+
+**Suggested fix:** Replace the Elvis-`continue` pattern with
+explicit `let { ... } ?: continue@outerLoop` or extract the
+cleanup into a helper that takes a non-null `Player?` and returns
+`Boolean`. Add a guard `if (player == null) { for ((obs,
+set) in hiddenPlayers) set.remove(uuid); return }` to drop the
+target's UUID from every observer's set regardless of Player
+availability.
+
+**Confidence:** med
+
+---
+
+### [SEV: med] items/AirdropFlareItem.kt:51-138 — `item.amount--` outside the coroutine references the original stack; item use can double-consume if the player swaps hands
+
+**What:** `onUse` reads `item: ItemStack` (the ItemStack passed by
+`CustomItemListener.onInteract` at line 70 of that listener, which
+passes `event.item`). Then `item.amount--` runs on line 137 *after*
+the `game.scope.launch { ... }` block has been queued. The coroutine
+inside does not touch `item`. The decrement is on the same stack
+object that the listener holds.
+
+But: `event.item` in `PlayerInteractEvent` is the *interact* item
+snapshot at event-fire time. If the player switches hands or the
+inventory is reorganised before the listener returns, the
+`item.amount--` mutates the *original* stack, not the current
+inventory slot. This is normally fine — the stack still has the
+correct amount — but a concurrent Bukkit task that mutates the
+held item (e.g., a re-give on respawn) could race.
+
+**Why it matters:** A duplicated-consume could occur if the same
+`ItemStack` is being passed by reference to two event handlers and
+both decrement. In this code, only `CustomItemListener.onInteract`
+calls `onUse`, so single-decrement is correct in normal use. But
+the comment in `CustomItemListener` line 64-67 only debounces by
+1-second cooldown, not by stack identity. If the player's
+cooldown expires mid-launch and they re-trigger, the same
+`item.amount--` from a *different* use-event decrements the
+already-decremented stack to -1 (which Bukkit clamps to 0 but
+firing the second `onUse` could matter for coroutine state).
+
+**Why lower:** Mostly defensive; the 1-second cooldown (line 42 of
+`CustomItemListener`) prevents rapid double-fire. But there is no
+`isCancelled` early-out after `item.amount--` for the case where
+`game.scope.launch` is queued but the coroutine's first `withContext`
+suspends long enough for another right-click to fire (e.g. the
+player click-spams while the announcement is in flight). Each
+click would re-enter `onUse`, re-launch a coroutine, re-decrement
+the item. The coroutines are not deduplicated by player, so multiple
+flares can be in flight simultaneously per player.
+
+**Suggested fix:** Add a per-player `flaringPlayers: Set<UUID>` set
+on `AirdropFlareItem` and check it at the top of `onUse`. Remove
+the entry when the chest-glow phase ends (line 122-134, the 9-second
+loop) or on `onQuit`.
+
+**Confidence:** med
+
+---
+
+### [SEV: low] chest/ChestManager.kt:132-138 — `createEnrichedSection` silently swallows `tier-weights` overrides nested under non-top-level keys
+
+**What:** `for (key in itemSection.getKeys(true))` returns all keys
+recursively (e.g., `enchantments.knockback`). The filter `!key.startsWith("tier-weights")`
+removes any key whose path begins with `tier-weights`, but if an admin
+nests a custom override under another section, it is copied verbatim.
+The `tier` and `chance` keys are also unconditionally overwritten with
+the *per-tier-loop* values, so a section like
+`some-section.tier: "rare"` is also overwritten by `enriched.set("tier", tier)`.
+
+**Why it matters:** No security implication — admins control the
+config. Minor correctness issue: the merging logic is fragile and
+non-obvious, making custom-config debugging harder. A future feature
+that adds nested config like `attributes.attack_damage` would be
+copied correctly, but a feature that adds `tier-weights` as a nested
+key elsewhere would be incorrectly filtered.
+
+**Suggested fix:** Document the merge contract in a comment; or use
+a typed builder that explicitly selects the keys to forward.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] chest/ChestItem.kt:84 — `nexoResolver` is a `@Volatile` static on a non-final data class
+
+**What:** `@Volatile var nexoResolver: ((String) -> ItemStack?)? = null`
+on the `companion object` of `ChestItem`. The function reference is
+captured at `init()` time and never refreshed. If `NexoHook` is
+reloaded (e.g. Nexo plugin is disabled mid-game and re-enabled), the
+resolver points at a stale closure and resolves to whatever the
+`NexoItems.itemFromId` call returns at that moment — possibly null
+silently (the wrapper at NexoHook:33 swallows exceptions).
+
+**Why it matters:** The fallback (a diamond with a warning lore) covers
+this case visually, but the resolver never being refreshed means
+chests filled after a Nexo reload use the same cached `(id → null)`
+mapping they had at startup. If a new Nexo item is added at runtime,
+chest items referencing it fall back to the diamond.
+
+**Suggested fix:** Reassign `nexoResolver` in
+`CustomItemsManager.reload()` (or in a Nexo plugin-enable listener)
+to the current `nexoHook::getNexoItem` reference. Or, more
+defensively, drop the cached resolver entirely and look up
+`NexoHook` directly via DI in `resolveItemStack`.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] items/SmokeGrenadeItem.kt:53-58 — `shutdown` cancels tasks but `activeClouds` may contain clouds whose tasks have already self-cancelled
+
+**What:** The shutdown iterates `activeClouds` and calls
+`cloud.task?.cancel()`, then `restoreAllVisibility()`, then
+`activeClouds.clear()`. A cloud whose task already self-cancelled
+(via `if (ticksElapsed >= cfg.durationTicks) { cancel();
+activeClouds.remove(cloudId); restoreVisibilityForCloud(cloud);
+return }` at line 98-103) is no longer in `activeClouds` by the
+time shutdown runs. But for clouds still in the map at shutdown,
+`restoreAllVisibility` runs *before* `activeClouds.clear()`. This
+means the `stillBlocked` check in `restoreVisibilityForCloud` (line
+251) sees the clouds that are about to be cleared — so it correctly
+preserves legitimately-blocked visibility. OK on closer reading, but
+the ordering is fragile.
+
+**Why it matters:** None, on inspection. Flagging for defensive-coding
+nit: a future refactor that swaps the `clear()` and
+`restoreAllVisibility()` order would introduce a visibility-leak
+bug.
+
+**Suggested fix:** Add a comment explaining the ordering invariant.
+
+**Confidence:** low
+
+---
+
+### [SEV: low] items/AirstrikeItem.kt:205-217 — `onItemHeld` and `onDrop` only cancel charge for the *previous* slot / dropped item, not the *new* slot
+
+**What:** `onItemHeld` (line 204-209) checks `oldItem` for the
+airstrike tag and cancels the charge. It does *not* check the
+`newItem` — but starting a charge requires `onUse` (right-click),
+not just holding, so this is correct. `onDrop` (line 212-217) is
+symmetric.
+
+**Why it matters:** None — flagged for completeness because the
+*inverse* bug (always cancelling on any swap) would silently disable
+the item. The current code is right.
+
+**Suggested fix:** None. Add a test that asserts the charge survives
+a hand-swap from off-hand to main-hand with the spyglass.
+
+**Confidence:** low
+
+---
+
+### Test-coverage gaps (med)
+
+The items package has **zero test coverage**. The following specific
+behaviours are untested but reachable in normal play:
+
+- **ChestManager fillChest double-chest behaviour** — should test that
+  a double chest has both halves populated from a single call, that
+  pre-existing items in the *other* half are cleared, and that the
+  `toBlockKey` de-dup in `ChestListener` (line 76, 104) treats a
+  double chest as one entry (currently it inserts two keys — one
+  per half — meaning the second half can be filled twice or the
+  halves can drift if `chunk.tileEntities` reports them in different
+  orderings).
+- **CustomItemsManager reload()** — should test that calling
+  `reload()` once does not register listeners twice. Currently this
+  is the only way to discover the duplicate-registration bug above.
+- **AirstrikeItem immune-list logic** — should test that in a duo
+  game where the caller throws an airstrike at the team's position,
+  both teammates take zero damage and the caller takes the meteor
+  damage (current behaviour is the opposite).
+- **AirdropFlareItem findSolidGround at world void** — should test
+  that calling with `impact.y = 0` does not place a floating chest
+  or NPE.
+- **PlayerTrackerItem findTopKiller while leader is offline** —
+  should test that the compass still points at the leader's UUID
+  slot once they reconnect, and that during the offline window the
+  marker is not shown on the wrong player.
+- **SmokeGrenadeItem rayIntersectsSphere edge cases** — should test
+  the `t1 < 0 && t2 > 1` "ray passes through" branch with a known
+  geometry (e.g. observer 5 blocks before sphere, target 5 blocks
+  after, both outside the sphere).
+- **GliderItem recentlyGliding grace window** — should test that
+  fall damage is cancelled exactly within 5 ticks of landing, and
+  taken exactly on the 6th tick.
+- **AirstrikeItem charge task exception recovery** — should test
+  that injecting an exception in `handleCharging` (e.g. by removing
+  the player mid-task) doesn't deadlock the charge state machine.
+
+---
+
+Files in this batch that have **no findings**:
+`CustomItem.kt`, `KnockbackStickItem.kt`, `PoisonBombItem.kt`,
+`BombItem.kt`, `FireBombItem.kt`. The simple items are correctly
+scoped: they spawn a single projectile with a metadata tag, the
+behavioural side-effects (damage, fire, particles) are handled in
+`CustomItemListener`, and there are no state machines to audit.
+`KnockbackStickItem` is a single-enchantment stick; the only
+subtlety is whether `Enchantment.KNOCKBACK, 5` is server-version
+compatible, which is out of scope for this audit.

--- a/docs/audit/audit-persistence.md
+++ b/docs/audit/audit-persistence.md
@@ -1,0 +1,520 @@
+# Audit Report: audit-persistence
+
+Batched audit of persistence/, statistics/, config/, and service/ArenaService — focused on
+SQL injection, transactional correctness, resource leaks, thread-safety, and game-integrity
+of stats / arena state.
+
+---
+
+## Findings
+
+### [SEV: high] persistence/repositories/PlayerStatsRepository.kt:64-65 — K/D and Win-Rate leaderboards are not actually computed
+**What:** `StatType.KILL_DEATH_RATIO` and `StatType.WIN_RATE` both fall through to ordering by
+the raw `kills` (or `wins`) column rather than computing the ratio. The enum in
+`domain/StatType.kt` explicitly documents the intent — `KILL_DEATH_RATIO` comment says
+`"computed from kills/deaths"`, `WIN_RATE` says `"computed from wins/gamesPlayed"`.
+**Why it matters:** Game-integrity exploit. A player with 100 kills / 100 deaths ranks above
+a player with 50 kills / 1 death on the K/D leaderboard. A player with 1 win / 1 game
+ranks above a player with 50 wins / 200 games on the Win-Rate leaderboard. Players can
+farm stats (or play only one short game) to dominate public leaderboards — directly
+breaks the gamified ranking feature the plugin advertises in `messages.killNotification`
+and `winnerAnnouncement`.
+**Suggested fix:** Compute the ratio in SQL (e.g. `CAST(kills AS DOUBLE) / NULLIF(deaths, 0)`
+and `CAST(wins AS DOUBLE) / NULLIF(games_played, 0)`) using a custom `Expression<*>`,
+and use `orderBy` on that. Alternatively, sort in Kotlin after fetching a bounded
+candidate set. Ensure the test for `KILL_DEATH_RATIO` actually asserts the ratio (see
+"test-coverage gap" below).
+**Confidence:** high
+
+---
+
+### [SEV: high] persistence/repositories/PlayerStatsRepository.kt:113 — `UUID.fromString` on stored column can crash the query
+**What:** `toPlayerStats()` does `UUID.fromString(this[PlayerStatsTable.uuid])` with no
+try/catch. A single corrupt UUID in any row causes the entire `findByUuid`,
+`getLeaderboard`, or `getTotalPlayerCount` call to throw `IllegalArgumentException`,
+which propagates out of the coroutine as an unhandled exception.
+**Why it matters:** Data-loss / data-corruption adjacent. One bad row (manual DB edit,
+partial migration, in-flight change) bricks every stats read path. The `ArenaRepository`
+correctly wraps `UUID.fromString` in `runCatching` (line 62) — this one was missed.
+**Suggested fix:** Wrap in `runCatching { UUID.fromString(this[PlayerStatsTable.uuid]) }
+.getOrElse { UUID(0L, 0L) }` and log a warning. (ArenaRepository's approach of
+substituting a fresh random UUID is also questionable — it would silently persist a
+different UUID on next upsert and break referential integrity — but at least it doesn't
+crash.)
+**Confidence:** high
+
+---
+
+### [SEV: high] persistence/DatabaseService.kt:91-96 — Primary-key detection is case-sensitive string match
+**What:** The legacy-table detector compares `rs.getString("COLUMN_NAME")` literally to
+`"name"`. If the primary key column is stored as `"NAME"`, `"Name"`, or `"NAME "`
+(any case or whitespace variant — common after hand-edits or third-party migration
+tools), the check returns `false` and the migration runs.
+**Why it matters:** The migration then `DROP TABLE arenas` and recreates from
+`arenas_new`. Even if data is preserved via the `INSERT … SELECT`, the rebuild is
+unnecessary work on a hot startup path. Worse, if the rebuild hits an error mid-flight
+(no `try/finally` around the `PRAGMA foreign_keys = OFF` at line 100), the `arenas`
+table is left in a half-migrated state and `PRAGMA foreign_keys` may stay `OFF` on
+the pooled connection — silently disabling FK enforcement for the rest of the session.
+**Suggested fix:** Compare case-insensitively and trim: `it.equals("name", ignoreCase = true)`.
+Wrap the `PRAGMA foreign_keys = OFF` / rebuild / `PRAGMA foreign_keys = ON` in
+`try { … } finally { stmt.executeUpdate("PRAGMA foreign_keys = ON") }` so a rebuild
+exception cannot leave FK enforcement disabled on the pooled connection.
+**Confidence:** med
+
+---
+
+### [SEV: high] persistence/CacheManager.kt:30-35 — `getOrPut` is not thread-safe (cache stampede / duplicate compute)
+**What:** `getOrPut` does `get(key)?.let { return it }` then `compute()` then `put(key, value)`.
+Two threads hitting a missing key simultaneously will both miss, both run `compute()`,
+and the loser's value silently overwrites the winner's. This is the classic
+double-checked-locking bug — `ConcurrentHashMap` does not help because the check and
+write are two separate operations.
+**Why it matters:** For a stats cache where `compute()` is a DB lookup, a cold key
+under a burst (e.g. several players join simultaneously) can trigger N parallel DB
+queries for the same data. For a computation that has side effects (e.g. inserts a new
+`PlayerStats` row, as `StatisticsService.getOrCreate` does at line 30), this can create
+duplicate rows.
+**Suggested fix:** Use the atomic `store.computeIfAbsent(key) { CacheEntry(compute(), Instant.now().plus(ttl)) }`,
+or hoist the cache write inside the same `compute()` lambda. Then expose a way to
+return the cached value without re-running `compute()` on the hit path
+(`computeIfAbsent` returns the existing-or-new value directly).
+**Confidence:** high
+
+---
+
+### [SEV: high] statistics/StatisticsService.kt:23-33 — `getOrCreate` has the same stampede + write-on-read bug as CacheManager
+**What:** `getOrCreate` does `cache[key]?.let { return it }` then a `statsRepo.findByUuid`
+then `PlayerStats(...).also { statsRepo.upsert(it) }` then `cache[key] = stats`. Two
+threads calling concurrently with a missing key will both miss the cache, both query
+the DB, and both upsert a freshly-minted `PlayerStats` row — creating a duplicate
+`(uuid, lootMode)` row that violates the primary key constraint at
+`PlayerStatsTable` line 27.
+**Why it matters:** Game-integrity. Duplicate rows would either be silently dropped by
+the upsert (losing the original's `playerName` and `createdAt` on race) or — if the
+PK enforcement path is loose — end up as two rows that the leaderboard then sums.
+Also see `preloadPlayerStats` (line 40) which calls this for all three loot modes on
+every player join, multiplying the race window.
+**Suggested fix:** Wrap the find-or-create in a per-key mutex (e.g. `ConcurrentHashMap<CacheKey, Mutex>`),
+or use the DB itself as the source of truth with `INSERT … ON CONFLICT DO NOTHING` and
+read back. At minimum, guard the `upsert` so it only fires when `findByUuid` actually
+returned `null` (not just as part of an `also` block that runs even on the hit path
+when the cache happens to be empty).
+**Confidence:** high
+
+---
+
+### [SEV: med] persistence/repositories/ArenaRepository.kt:62 — Silently substituting `UUID.randomUUID()` on parse failure
+**What:** `id = runCatching { UUID.fromString(this[ArenaTable.id]) }.getOrDefault(UUID.randomUUID())`.
+If the stored `id` column is corrupt or empty, the loader synthesises a brand-new
+random UUID, then `ArenaRepository.save` (line 36) writes that fresh UUID back to the
+row.
+**Why it matters:** The `id` column is not the primary key (the PK is `name`), but it
+is still a stable identifier used elsewhere in the plugin. Replacing it on load + save
+silently rotates the arena's id. Any external system or future migration that joins
+on `id` will lose track of the arena. Worse, on first load after corruption the cache
+holds the random id; on save the row is updated; on next load the same logic produces
+a *different* random id and overwrites again — only the first one is recoverable.
+**Suggested fix:** Use a sentinel `UUID(0L, 0L)` and log a `logger.warn(...)` so the
+operator knows the row is bad and can repair it. Do not auto-rotate.
+**Confidence:** high
+
+---
+
+### [SEV: med] persistence/repositories/ArenaRepository.kt:69-91 — `runCatching { gson.fromJson(...) }.getOrDefault(...)` silently swallows every JSON / material parse error
+**What:** Four separate `runCatching` blocks silently coerce failure to
+`emptyList()` / `getOrNull()` / `Arena.DEFAULT_ALLOWED_BLOCKS`. There is no logging.
+**Why it matters:** Game-integrity. A bad row in `spawn_points_json` or
+`chest_locations_json` (e.g. truncated, schema drift after a Gson upgrade) causes the
+arena to load with **zero spawn points and zero chest locations**. The game will then
+place players at the literal world spawn (or 0,0,0) and no chest loot will ever fire —
+a complete silent feature break with no operator signal. The `allowedBlocks` fallback
+to `DEFAULT_ALLOWED_BLOCKS` is a different design choice but again without logging the
+operator never knows their saved `allowedBlocks` was rejected.
+**Suggested fix:** On each catch, log at WARN level with the arena name and the
+malformed JSON. For the spawn-points / chest-locations case, return an explicit "broken
+arena" sentinel (or refuse to load the arena entirely) rather than loading a half-empty
+arena. Consider a strict Gson type-adapter that fails loudly.
+**Confidence:** high
+
+---
+
+### [SEV: med] service/ArenaService.kt:26, 44-47, 57-61 — `loadAll`, `save`, `removeArena` have no transactional cache/DB consistency
+**What:**
+- `loadAll()` (`@PostConstruct` on a `suspend fun` — see line 26) loads arenas from
+  the DB into the in-memory `cache`. The cache is then used as the source of truth.
+- `save(arena)` writes to the DB *then* updates the cache. If the DB write throws,
+  the new in-memory value still goes into the cache on line 46? No — re-reading, the
+  call is `arenaRepo.save(arena); cache[…] = arena`, so the cache is only updated
+  after a successful save. But if `saveAll()` (line 49-51) iterates `cache.values`
+  and the DB throws partway through, the cache remains "saved" while the DB is
+  partially written — no rollback is possible.
+- `removeArena(arena)` removes from cache first (line 58) then deletes from DB
+  (line 59). If the DB delete throws, the cache is now empty but the row remains —
+  on next restart the arena reappears.
+
+**Why it matters:** Data-loss in normal use. Server crash or DB hiccup mid-`saveAll`
+leaves a half-persisted arena set; on reload, arenas that were "saved" in cache but
+not yet flushed are lost (because the cache is cleared in `stop()` at line 33 before
+the DB shutdown). The `removeArena` ordering is also surprising: it is a *cache-first*
+delete, so a DB failure causes the row to survive a restart that the operator believed
+already removed it.
+**Suggested fix:** Treat the DB as source of truth. `save` → DB first, then refresh
+cache from the saved row (or do `arenaRepo.save`; `cache[…] = arenaRepo.findByName(...)`
+to be sure the cached value is the one actually persisted). `removeArena` → DB first,
+then `cache.remove` only on success. For `saveAll`, use a single transaction
+(`dbQuery { for (...) upsert {} }`) so a failure rolls back atomically.
+**Confidence:** med
+
+---
+
+### [SEV: med] service/ArenaService.kt:23, 79-88 — `selectedArenas` map is never evicted on player quit
+**What:** `selectedArenas: ConcurrentHashMap<UUID, String>` stores the player's currently
+admin-selected arena. `clearSelectedArena` (line 86) exists but is not wired up to a
+`PlayerQuitEvent` listener. `stop()` (line 32-35) clears the map only on plugin
+shutdown.
+**Why it matters:** Slow memory leak. Each time an admin selects an arena and logs
+out, the entry stays in the map forever. For a long-running server with rotating
+admin staff this grows without bound. (There is a separate `selectedArenas` in
+`AdminWandListener.kt:38` that *is* cleaned up on quit — that one is the actual
+production path; the unused one in `ArenaService` looks like dead/draft code. Either
+way it is misleading.)
+**Suggested fix:** Either wire `clearSelectedArena` to a `PlayerQuitEvent`, or
+delete the unused `selectedArenas` / `setSelectedArena` / `getSelectedArena` /
+`clearSelectedArena` from `ArenaService` if `AdminWandListener`'s copy is the real
+one.
+**Confidence:** med
+
+---
+
+### [SEV: med] statistics/StatisticsService.kt:53-80 — Every per-kill / per-damage event is two DB round-trips
+**What:** `recordKill`, `recordDeath`, `recordDamageDealt`, `recordDamageTaken`, and
+`recordChestOpened` each do `statsRepo.findByUuid(...)` followed by `statsRepo.upsert(...)`.
+`recordDamageDealt` and `recordDamageTaken` are never called from the production
+code path (the only call sites are in `Game.kt:233-243` which only mutate the
+in-memory `GamePlayer`); they appear to be dead code. `recordKill` and `recordDeath`
+*are* called from `PlayerListener.kt:120` on death.
+**Why it matters:** Resource leak / performance under load. A 24-player game with
+several kills per second creates 2N+2 DB queries per kill (2 for the killer, 2 for
+the victim). On a small Hikari pool (`maximumPoolSize = 1` for SQLite per
+`DatabaseService.kt:43`, default 8 for MySQL) this can starve the pool and back up
+the coroutine dispatcher. SQLite is hit *twice as hard* because every write
+serialises through the single-writer connection.
+**Suggested fix:** Batch. The `Game` already accumulates the per-player kill / damage
+totals in `GamePlayer` (see `Game.kt:233-243`). `recordGameEnd` already iterates
+`game.players.values` and writes once. Delete the per-event `recordKill` /
+`recordDeath` from `StatisticsService` and let `recordGameEnd` do the work, or
+introduce a periodic flush (every N seconds / events) with `saveAllPendingStats` —
+the batching infrastructure is already there.
+**Confidence:** med
+
+---
+
+### [SEV: med] statistics/StatisticsService.kt:86 — `gameTime` is computed and never used
+**What:** `val gameTime = game.getTimeRemaining().toLong()` on line 86 is assigned but
+never referenced afterwards. The variable is dead.
+**Why it matters:** Style nit with a real consequence: a future maintainer reading the
+function will assume `gameTime` is being persisted (and look for the bug in the
+DB-write path) when actually the function silently never records total game duration
+in `totalTimePlayed`. `PlayerStats.totalTimePlayed` is incremented *only* via
+`getAggregatedStats` (line 165), never on a per-game basis.
+**Suggested fix:** Either remove the dead variable, or actually compute
+`game.startedAt → now` and add it to `stats.totalTimePlayed` in the `recordGameEnd`
+upsert.
+**Confidence:** high
+
+---
+
+### [SEV: med] statistics/StatisticsService.kt:97 — `placement` defaults to `totalPlayers` for unplaced players
+**What:** `val placement = gp.placement.takeIf { it > 0 } ?: totalPlayers`. If
+`GamePlayer.placement` is left at its default `0` (which happens for any player who
+disconnects before the game finalises their placement), the function attributes to
+them a placement equal to the number of *participants*, not the number of *finishers*.
+**Why it matters:** Game-integrity. A player who rage-quits at 10 players alive
+silently gets recorded as "10th place" and increments their `top3Finishes` only if
+`placement <= 3` (so they don't get an undeserved top-3, OK) — but their
+`bestPlacement` is overwritten with `10`, which is *worse* than the truth (they
+should retain their previous best, not get a permanent "10th place" stamp). For a
+player who previously had a 1st-place best, a ragequit can lock their `bestPlacement`
+at the player count of whatever game they quit.
+**Suggested fix:** Do not overwrite `bestPlacement` when the game's placement is
+indeterminate. Either skip the placement update for `gp.placement == 0`, or record
+`Int.MAX_VALUE` and use a `min` that ignores the sentinel. (Also note the
+double-condition at line 110: `stats.bestPlacement == 0 || placement < stats.bestPlacement`
+— the `== 0` short-circuit means the first game with a real placement always wins,
+which is fine, but the `placement = totalPlayers` default makes this worse.)
+**Confidence:** med
+
+---
+
+### [SEV: med] statistics/StatisticsService.kt:148-172 — `getAggregatedStats` returns a `PlayerStats` with a fake `lootMode`
+**What:** The aggregated result is constructed with `lootMode = LootMode.MODERN` and a
+comment `"placeholder — aggregate has no single mode"`. The shape is a regular
+`PlayerStats`, so any caller that doesn't know it's aggregated and passes it back to
+`statsRepo.upsert` (e.g. via `savePlayerStats`) will silently write garbage to the
+MODERN row for that player — overwriting real MODERN stats with a sum that includes
+CLASSIC and OP.
+**Why it matters:** Data corruption footgun. Not currently triggered by production
+callers, but a refactor that "simplifies" the stats layer to pass the aggregated
+value through the existing save path will wipe a player's MODERN row. The
+`PlayerStats(uuid, playerName, lootMode = …)` constructor itself doesn't reject
+this misuse.
+**Suggested fix:** Make `getAggregatedStats` return a dedicated `AggregatedPlayerStats`
+type (or a `Map<LootMode, PlayerStats>`). Or, if the current shape must stay, use a
+sentinel `lootMode` enum value like `LootMode.AGGREGATE` that `PlayerStatsTable` will
+reject (it has no row for `AGGREGATE`, so the upsert would fail loudly rather than
+silently overwriting).
+**Confidence:** med
+
+---
+
+### [SEV: med] statistics/StatisticsService.kt:166 — `bestPlacement` aggregation reads `Int.MAX_VALUE` then unwraps via `takeIf`
+**What:**
+```kotlin
+bestPlacement = allModeStats.minOfOrNull { it.bestPlacement.takeIf { p -> p > 0 } ?: Int.MAX_VALUE }
+    ?.takeIf { it != Int.MAX_VALUE } ?: 0
+```
+Works, but is a three-deep null-and-sentinel dance. A single-mode player with
+`bestPlacement = 0` correctly gets `0` out, but the path is fragile — a future
+maintainer who removes one `takeIf` will silently make every player look like they
+have "1st place best" because the min of `{0, 0, 0}` after `takeIf { > 0 }` returns
+empty and `minOfOrNull` on an empty sequence returns `null` → the `?:` returns `0`.
+That part is correct, but the readability cost is real.
+**Why it matters:** Style / maintainability with a latent correctness trap.
+**Suggested fix:** Extract a helper:
+```kotlin
+fun bestPlacementAcross(modes: List<PlayerStats>): Int =
+    modes.mapNotNull { it.bestPlacement.takeIf { p -> p > 0 } }.minOrNull() ?: 0
+```
+**Confidence:** low (style-leaning)
+
+---
+
+### [SEV: med] persistence/DatabaseService.kt:99-139 — `migrateSqliteLegacyArenasTable` has no `try/finally` around `PRAGMA foreign_keys`
+**What:** Lines 100 and 138 set `PRAGMA foreign_keys = OFF` and back to `ON`. There is
+no `try/finally`. If any of the `executeUpdate` calls between them throws (e.g.
+`CREATE TABLE arenas_new` fails due to disk full, `DROP TABLE arenas` fails because
+another connection holds it, etc.), the connection returns to the Hikari pool with
+`foreign_keys = OFF`. SQLite enforces `PRAGMA foreign_keys` per-connection, so the
+*next* user of that pooled connection will have FK enforcement disabled.
+**Why it matters:** Data-integrity. The `game_history` table has
+`arenaName references ArenaTable.name` (`tables/GameHistoryTable.kt:8`). With FK
+enforcement off, an admin deleting an arena no longer cascades (or rather, no longer
+blocks) the orphan `game_history` rows. The orphaned rows would survive in the DB
+and re-appear in any future migration that adds a real cascade.
+**Suggested fix:**
+```kotlin
+try {
+    stmt.executeUpdate("PRAGMA foreign_keys = OFF")
+    // … rebuild …
+} finally {
+    runCatching { stmt.executeUpdate("PRAGMA foreign_keys = ON") }
+}
+```
+Also consider doing the rebuild in a single `transaction { … }` block so SQLite
+itself rolls back on failure.
+**Confidence:** med
+
+---
+
+### [SEV: med] persistence/DatabaseService.kt:65-75 — Migration runs `transaction { SchemaUtils.createMissingTablesAndColumns(...) }` but legacy migration runs *before* it
+**What:** `init()` calls `migrateSqliteLegacyArenasTable()` at line 66, then
+`transaction { SchemaUtils.createMissingTablesAndColumns(...) }` at line 69-75.
+`createMissingTablesAndColumns` may also try to `ALTER TABLE` to add the primary key
+to `arenas` on a legacy schema — which `SQLite` cannot do. If the legacy migration
+above fails (e.g. because the table doesn't exist yet, which it returns-early on, but
+also because of the `PRAGMA foreign_keys` bug above), the `createMissingTablesAndColumns`
+will either error out or silently fail to add the PK.
+**Why it matters:** Data-integrity on first startup. There is no test for this path
+(see "test-coverage gap" below). The order is correct *in principle* (legacy first,
+then add-columns), but the two paths are not coordinated.
+**Suggested fix:** Run both inside the same `transaction` block so a failure in
+either rolls both back. Add a test that starts from a pre-migration schema (table
+without PK) and asserts the final schema is correct.
+**Confidence:** low
+
+---
+
+### [SEV: low] config/LumaSGConfig.kt:333 — Discord bot token stored as plaintext `String` in config
+**What:** `var botToken: String = ""` in `DiscordConfig`. There is no encryption, no
+environment-variable indirection, no permission check on the file.
+**Why it matters:** Secret leakage. If the operator commits the populated config to
+git, or shares a debug bundle that includes the plugin data folder, the bot token
+leaks. The comment says "keep secure, never share" but the config-loading code does
+nothing to enforce that.
+**Suggested fix:** Either (a) read the token from an environment variable at startup
+with the config value as a fallback / path to a separate file, or (b) at minimum,
+log a one-time warning at startup if `botToken.isNotBlank()` that reminds the
+operator to keep the file out of version control, and exclude `config.yml` from
+the build artifact.
+**Confidence:** low (the bot token is only used in one place, `DiscordService.kt:30`,
+and the default is empty — leakage requires operator action)
+
+---
+
+### [SEV: low] persistence/repositories/PlayerStatsRepository.kt:81-83 — `getTotalPlayerCount` counts (uuid, mode) pairs, not unique players
+**What:** `PlayerStatsTable.selectAll().count()` returns the row count, but the PK is
+`(uuid, lootMode)` (line 27 of the table). One player who has played all three loot
+modes contributes three rows.
+**Why it matters:** Likely-surprise bug. Whatever consumes this count (e.g. a Discord
+stat embed, a server-info command) will report a player count 3× the actual
+population.
+**Suggested fix:** `PlayerStatsTable.uuid.countDistinct()` (Exposed: `PlayerStatsTable.uuid.countDistinct()`).
+**Confidence:** med
+
+---
+
+### [SEV: low] persistence/repositories/PlayerStatsRepository.kt:85-110 — `savePlayerStatsBatch` issues N separate upserts
+**What:** The batch is implemented as a `for (stats in statsList) { … upsert … }`
+inside one `dbQuery`, which is one transaction. The `upsert` DSL call is still N
+round-trips to the DB.
+**Why it matters:** Performance under load. For a server with 100+ players this is
+noticeable, especially over a network DB. A single `INSERT … ON CONFLICT … DO UPDATE`
+batch would be a fraction of the cost.
+**Suggested fix:** Use Exposed's `batchInsert` with an `onUpdate` / `onConflict`
+clause, or build a single multi-row upsert.
+**Confidence:** med
+
+---
+
+### [SEV: low] persistence/CacheManager.kt:23-24, 39, 45 — TTL eviction is best-effort; size cap never enforced
+**What:** `put` calls `evictExpired()` only when `store.size >= maxSize`. If the
+caller `getOrPut`s with a key that hasn't expired and the size is at `maxSize`, no
+eviction is triggered — but a new key is still inserted, pushing the size past
+`maxSize` by 1 (and then the eviction runs, removing the *new* entry's
+contemporaries, but the new entry itself remains). There is no actual cap.
+**Why it matters:** The `maxSize` parameter is documented in the class comment as
+"max size" but it is a soft target, not a hard cap. Indefinite growth is possible
+if the workload has many short-lived keys that arrive faster than they expire.
+**Suggested fix:** Enforce: if `store.size >= maxSize` after `evictExpired()` and
+size is still at the cap, refuse the insert (or evict the oldest). Use
+`store.compute` with a size check.
+**Confidence:** low
+
+---
+
+### [SEV: low] persistence/DatabaseExtensions.kt:7-9 — `dbQuery` uses `Dispatchers.IO` which is unbounded
+**What:** `Dispatchers.IO` has a default max of 64 threads, can grow with
+`systemProp`. Every `dbQuery { }` spawns (or reuses) an IO thread. There is no
+back-pressure: a burst of N caller coroutines that all `dbQuery` simultaneously
+can occupy N IO threads, blocking the coroutine dispatcher used elsewhere.
+**Why it matters:** Performance under load, especially on a server with many
+players all calling stats reads / writes at the same time. Not a correctness bug.
+**Suggested fix:** Consider a bounded `Executors.newFixedThreadPool(db.pool.maximumPoolSize * 2)`
+and `withContext(pool.asCoroutineDispatcher())`, or set `Dispatchers.IO.limitedParallelism(N)`.
+**Confidence:** low
+
+---
+
+### [SEV: low] statistics/StatisticsService.kt:40-45 — `preloadPlayerStats` writes a stats row for every player on join
+**What:** `preloadPlayerStats` calls `getOrCreate` for *all three* `LootMode.entries`
+on every player join. `getOrCreate` upserts a freshly-minted `PlayerStats` if none
+exists for that `(uuid, mode)`. A player who joins, looks at the lobby for 10
+seconds, and leaves now has 3 rows in `player_stats`.
+**Why it matters:** Resource leak / data hygiene. Over a long-running server the
+table accumulates rows for every player who ever connected, even if they never
+played. (Compare to the cache-hit path in `getOrCreate`: the *cache* is correctly
+populated without a DB write, but the very first call for a mode where the row is
+missing still triggers an upsert.)
+**Suggested fix:** Distinguish "load or return existing" from "load or create". The
+latter should not be called from `preloadPlayerStats`; only the former. A player
+who hasn't played a mode yet should simply have no row until they play it.
+**Confidence:** med
+
+---
+
+### [SEV: low] config/LumaSGConfig.kt:296-314 — `DatabaseConfig.type` is a free-form String, not an enum
+**What:** `var type: String = "SQLITE"` — the value is matched in
+`DatabaseService.kt:38` via `db.type.uppercase()` and falls into an `else -> error(...)`
+branch for unknown values. The error is thrown at startup (fine) but the config
+itself does not constrain the value, so a typo (`"SQLLITE"`) fails late and
+cryptically.
+**Why it matters:** Operator experience. Also means the IDE / config-validation layer
+can't suggest valid values.
+**Suggested fix:** `var type: DatabaseType = DatabaseType.SQLITE` where
+`DatabaseType` is an enum with `MYSQL`, `MARIADB`, `POSTGRESQL`, `SQLITE`. Default
+to a value that gives a friendly error if the type is unknown.
+**Confidence:** low
+
+---
+
+### [SEV: low] config/LumaSGConfig.kt:298, 220 — API URLs and SQLite file path are concatenable, no validation
+**What:**
+- `var sqliteFile: String = "lumasg.db"` is resolved via `plugin.dataFolder.resolve(db.sqliteFile)`
+  and then put straight into a JDBC URL: `jdbc:sqlite:${dbFile.absolutePath}`. A
+  malicious or misconfigured value containing `?` or `;` could break the JDBC URL
+  parsing.
+- `var apiUrl: String = "https://starlightskins.lunareclipse.studio/..."` is used
+  elsewhere (not in this batch) by substituting `<name>` — an unencoded player
+  name with `?` or `#` would corrupt the URL. (Worth flagging because the
+  `<name>` placeholder is exactly the URL-injection surface.)
+
+**Why it matters:** Security. Both are config-controlled so exploitation requires
+operator misconfiguration, but a generated-config UI (e.g. an in-game setup wizard)
+that lets an admin paste a URL becomes the attack surface.
+**Suggested fix:** Validate `sqliteFile` is a simple filename (no `..`, no path
+separators, no URL metacharacters). URL-encode `<name>` when substituting into
+`apiUrl`. Or, simpler, build the JDBC URL via `URI` and validate.
+**Confidence:** low
+
+---
+
+### [SEV: low] service/ArenaService.kt:53-55 — `addToCache` is misleadingly named and only updates memory
+**What:** `fun addToCache(arena: Arena) { cache[arena.name.lowercase()] = arena }`.
+Used by `AdminWandListener.kt:89, 99` for in-progress arena edits. There is no DB
+write. A caller that uses this expecting persistence loses data on the next
+plugin restart.
+**Why it matters:** Defensive-coding nit. The current callers know the rule, but
+the function name suggests "save to cache" which sounds like "save for next time".
+**Suggested fix:** Rename to `updateLocalArena` or `stageArenaUpdate`, and add a
+KDoc that explicitly says "in-memory only; call `save()` to persist".
+**Confidence:** low
+
+---
+
+## Test-coverage gaps
+
+The following behaviour is currently untested. Each gap has a corresponding
+real-bug risk in the production code.
+
+| Untested behaviour | Where the bug would live | Test that should exist |
+|---|---|---|
+| `getOrPut` is safe under concurrent calls (no stampede) | `CacheManager.kt:30-35` | `CacheManagerConcurrentTest`: 8 threads call `getOrPut` for the same key with an `AtomicInteger` counter in `compute`; assert counter == 1. |
+| `getOrCreate` is safe under concurrent calls (no duplicate `PlayerStats` rows) | `StatisticsService.kt:23-33` | `StatisticsServiceConcurrentTest` (or integration test against H2): 8 threads call `getOrCreate` for the same `(uuid, mode)`; assert exactly one row in `PlayerStatsTable`. |
+| `KILL_DEATH_RATIO` leaderboard actually orders by `kills / deaths` | `PlayerStatsRepository.kt:64-65` | A unit test that inserts (kills=100, deaths=100) and (kills=50, deaths=1) and asserts the second is ranked first. Currently the test at `PlayerStatsRepositoryTest.kt:73-81` only covers the `KILLS` case. |
+| `WIN_RATE` leaderboard actually orders by `wins / games_played` | `PlayerStatsRepository.kt:65` | Similar to above: (wins=50, games_played=200) should rank below (wins=1, games_played=1). |
+| `ArenaRepository.toArena` does not silently return empty spawn points on bad JSON | `ArenaRepository.kt:69-91` | Insert a row with malformed `spawn_points_json`; assert either the load throws *or* the operator is warned — definitely do not assert `emptyList()`. |
+| `ArenaRepository.toArena` does not silently substitute `UUID.randomUUID()` on bad `id` | `ArenaRepository.kt:62` | Insert a row with `id = "not-a-uuid"`; assert behaviour is logged and stable across re-reads. |
+| `DatabaseService.migrateSqliteLegacyArenasTable` rebuilds a legacy table and preserves all data | `DatabaseService.kt:85-142` | Integration test against SQLite: create a legacy `arenas` table without a PK, populate 10 rows, run the migration, assert the new table has the 10 rows and the new PK constraint. Also test the case where the migration throws mid-way (e.g. by mocking a `Statement` that fails on `DROP TABLE`) and assert `PRAGMA foreign_keys` is reset to `ON` on the pooled connection. |
+| `recordGameEnd` aggregates `gp.placement` correctly for rage-quitters | `StatisticsService.kt:83-121` | A unit test with a `GamePlayer` whose `placement == 0` (the default) and a non-zero `bestPlacement` on the existing stats row; assert `bestPlacement` is *not* overwritten with the ragequit game's `totalPlayers`. |
+| `getAggregatedStats` returns a sum, not a snapshot of one mode | `StatisticsService.kt:148-172` | Insert three rows for the same uuid (one per mode); assert the aggregated kills = sum of all three. |
+| `getTotalPlayerCount` returns unique-player count, not row count | `PlayerStatsRepository.kt:81-83` | Insert two rows for the same uuid (different modes); assert count == 1, not 2. |
+| `getOrCreate` for a player who has never played does not write a row | `StatisticsService.kt:23-33` (and `preloadPlayerStats:40-45`) | Call `preloadPlayerStats` for a brand-new uuid; assert `PlayerStatsTable.select { uuid eq … }.count() == 0` afterwards. |
+| `CacheManager.put` respects the `maxSize` cap as a hard limit | `CacheManager.kt:38-47` | Insert `maxSize + N` non-expiring keys; assert `size() <= maxSize` after each insert. |
+| `ArenaService.removeArena` is cache+DB consistent under DB failure | `ArenaService.kt:57-61` | Mock `ArenaRepository.delete` to throw; assert the arena is *still* in the cache. |
+| `DatabaseService.init` rejects unknown `database.type` with a clear error | `DatabaseService.kt:38-60` | Construct a `LumaSGConfig` with `database.type = "ORACLE"`; assert a descriptive `IllegalStateException` is thrown mentioning the unsupported value. |
+| `LumaSGConfig` validation: `minPlayers > maxPlayers` | `LumaSGConfig.kt:66-68` | Assert the config loader (wherever it lives) either clamps or warns on this misconfiguration. |
+
+---
+
+## Files reviewed
+
+```
+src/main/kotlin/net/lumalyte/lumasg/config/LumaSGConfig.kt             (461 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/CacheManager.kt        ( 67 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/DatabaseExtensions.kt   (  9 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/DatabaseService.kt      (151 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/repositories/ArenaRepository.kt         ( 95 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/repositories/PlayerStatsRepository.kt    (133 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/tables/ArenaTable.kt                   ( 24 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/tables/GameHistoryTable.kt              ( 17 lines)
+src/main/kotlin/net/lumalyte/lumasg/persistence/tables/PlayerStatsTable.kt              ( 28 lines)
+src/main/kotlin/net/lumalyte/lumasg/service/ArenaService.kt                             ( 89 lines)
+src/main/kotlin/net/lumalyte/lumasg/statistics/StatisticsService.kt                     (173 lines)
+```
+
+Plus context: `domain/Arena.kt`, `domain/LootMode.kt`, `domain/StatType.kt`,
+`game/Game.kt`, `game/GamePlayer.kt`, `listeners/PlayerListener.kt`,
+`listeners/AdminWandListener.kt`, `discord/DiscordService.kt`, and the two
+existing test files `persistence/CacheManagerTest.kt` and
+`persistence/PlayerStatsRepositoryTest.kt`.


### PR DESCRIPTION
## Mass audit of LumaSG (findings-only, no source changes)

One Hermes coordinator (`deepseek/deepseek-v4-flash`) + 6 subagents (`minimax/minimax-m3`) audited all 86 main sources at `5baa40f` in disjoint batches. 127 raw findings; every critical/high was then manually verified against source, severities corrected, and 4 false positives documented and removed.

**Read first:** `docs/audit/MASS-AUDIT-2026-06-10.md` — the triaged consolidation.

### Verified criticals
1. `Game.reconnectPlayer` re-snapshots mid-game loot over the pre-game inventory — data loss + disconnect/reconnect dupe
2. `Arena.scanForChests()` — ~385M main-thread block lookups at default radius 500 (full server freeze)
3. `GameBrowserMenu` / `Game.addPlayer` — no phase guard; players can join live Active/Deathmatch games

### Verified highs (16)
Fake K/D & Win-Rate leaderboards, `/sg forcestart` no-op, `Team.isAlive` keyed on online status, queue-team dual membership, zeroed stats cached for 30 min on DB failure, Bukkit API on Caffeine worker threads, inverted airstrike friendly-fire immunity, `reload()` double-registering listeners, cross-arena chest fills, bomb damage bypassing phase/friendly-fire, console command arg-injection via name substitution, and more — full list with file:line and fix directions in the master report.

### Contents
- `docs/audit/MASS-AUDIT-PLAN.md` — methodology, rubric, batch table
- `docs/audit/audit-{game,items,gui-commands,persistence,domain-util,hooks-misc}.md` — raw batch reports (127 findings)
- `docs/audit/COORDINATOR-SUMMARY.md` — coordinator roll-up
- `docs/audit/MASS-AUDIT-2026-06-10.md` — **triaged master report** (verified findings, corrected severities, false positives, top-5 missing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Features**

- Add comprehensive mass audit report with 127 verified findings and triage metadata (MASS-AUDIT-2026-06-10.md)
- Add audit methodology, severity rubric, and batch partition plan (MASS-AUDIT-PLAN.md)
- Add batch audit reports for game, items, GUI/commands, persistence, domain/util, and hooks/misc modules
- Add coordinator-level summary with cross-cutting themes and top 10 findings (COORDINATOR-SUMMARY.md)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->