### PR TITLE
fix(arena/chest): audit batch D — 1 crit + 2 high (C2, H12, H13)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,8 +25,8 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
 
     // Nexus DI + coroutines (local Maven)
-    implementation("net.badgersmc:nexus-core:1.6.0")
-    implementation("net.badgersmc:nexus-paper:1.6.0")
+    implementation("com.github.BadgersMC.Nexus:nexus-core:v2.2.1")
+    implementation("com.github.BadgersMC.Nexus:nexus-paper:v2.2.1")
 
     // Kotlin (downloaded at startup by LumaSGLoader)
     compileOnly(kotlin("stdlib"))

--- a/src/main/kotlin/net/lumalyte/lumasg/domain/Arena.kt
+++ b/src/main/kotlin/net/lumalyte/lumasg/domain/Arena.kt
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.Particle
+import org.slf4j.LoggerFactory
 import java.util.UUID
 
 data class Arena(
@@ -31,11 +32,21 @@ data class Arena(
     /**
      * Scans the arena world for chest blocks within [radius] of center.
      * Returns the discovered chest locations. Must be called on main thread.
+     *
+     * The scan radius is capped at [MAX_CHEST_SCAN_RADIUS]: an uncapped cubic scan at the
+     * default radius of 500 is ~10^9 `getBlockAt` calls and freezes the main thread for
+     * minutes (C2). A radius beyond the cap is clamped and logged so the operator knows.
      */
     fun scanForChests(): List<SerializableLocation> {
         val world = Bukkit.getWorld(worldName) ?: return emptyList()
         val centerLoc = center.toBukkit() ?: return emptyList()
-        val r = radius.toInt()
+        if (!isChestScanRadiusSafe(radius)) {
+            logger.warn(
+                "Arena '{}' chest-scan radius {} exceeds the safe cap of {}; clamping to avoid a main-thread freeze.",
+                name, radius.toInt(), MAX_CHEST_SCAN_RADIUS
+            )
+        }
+        val r = radius.toInt().coerceIn(0, MAX_CHEST_SCAN_RADIUS)
         val cx = centerLoc.blockX
         val cy = centerLoc.blockY
         val cz = centerLoc.blockZ
@@ -68,6 +79,15 @@ data class Arena(
     fun cleanup() { /* no-op: DB-backed arena has no runtime state to clean */ }
 
     companion object {
+        private val logger = LoggerFactory.getLogger(Arena::class.java)
+
+        /** Hard cap on the [scanForChests] radius — keeps the cubic scan bounded (C2). */
+        const val MAX_CHEST_SCAN_RADIUS: Int = 64
+
+        /** Whether [radius] is within the safe cap for an on-main-thread chest scan. */
+        fun isChestScanRadiusSafe(radius: Double): Boolean =
+            radius >= 1.0 && radius <= MAX_CHEST_SCAN_RADIUS
+
         val DEFAULT_ALLOWED_BLOCKS: Set<Material> = setOf(
             Material.TALL_GRASS, Material.SHORT_GRASS, Material.FERN,
             Material.DEAD_BUSH, Material.VINE, Material.LILY_PAD,

--- a/src/main/kotlin/net/lumalyte/lumasg/listeners/ChestListener.kt
+++ b/src/main/kotlin/net/lumalyte/lumasg/listeners/ChestListener.kt
@@ -37,8 +37,11 @@ class ChestListener(
     private val logger = LoggerFactory.getLogger(ChestListener::class.java)
     private val mm = MiniMessage.miniMessage()
 
-    /** Tracks which chests have already been filled (by block location hash). */
-    private val filledChests = ConcurrentHashMap.newKeySet<Long>()
+    /**
+     * Tracks which chests have already been filled, keyed by "arenaName:blockKey" so two
+     * arenas sharing a world keep independent fill state (H13).
+     */
+    private val filledChests = ConcurrentHashMap.newKeySet<String>()
 
     @PostConstruct
     fun register() {
@@ -59,21 +62,29 @@ class ChestListener(
         val chunk = event.chunk
         val worldName = chunk.world.name
 
-        // Find the game running in this world (if any)
-        val game = gameManager.getAllActiveGames().firstOrNull {
-            it.arena.worldName == worldName
-        } ?: return
-
-        // Only fill during active gameplay phases
-        val phase = game.phase
-        if (phase is GamePhase.Waiting || phase is GamePhase.Countdown || phase is GamePhase.Ended) return
+        // All games active (in a fillable phase) in this world. Multiple arenas can share
+        // a world, so we resolve the owning game per chest by arena bounds (H13).
+        val games = gameManager.getAllActiveGames().filter { g ->
+            g.arena.worldName == worldName &&
+                g.phase !is GamePhase.Waiting &&
+                g.phase !is GamePhase.Countdown &&
+                g.phase !is GamePhase.Ended
+        }
+        if (games.isEmpty()) return
 
         // Scan chunk tile entities for chests and fill any that haven't been filled yet
         val tileEntities = chunk.tileEntities
         var filled = 0
         for (state: BlockState in tileEntities) {
             if (state !is Chest) continue
-            val locKey = state.location.toBlockKey()
+            // Only fill a chest with the game whose arena bounds actually contain it.
+            val game = games.firstOrNull { g ->
+                val center = g.arena.center.toBukkit() ?: return@firstOrNull false
+                state.location.world == center.world &&
+                    state.location.distanceSquared(center) <= g.arena.radius * g.arena.radius
+            } ?: continue
+
+            val locKey = "${game.arena.name}:${state.location.toBlockKey()}"
             if (!filledChests.add(locKey)) continue // already filled
 
             val tier = determineTier(state, game)
@@ -82,8 +93,8 @@ class ChestListener(
         }
 
         if (filled > 0) {
-            logger.debug("Chunk [{}, {}] loaded — filled {} chests (arena '{}')",
-                chunk.x, chunk.z, filled, game.arena.name)
+            logger.debug("Chunk [{}, {}] loaded — filled {} chests in world '{}'",
+                chunk.x, chunk.z, filled, worldName)
         }
     }
 
@@ -101,7 +112,7 @@ class ChestListener(
         val phase = game.phase
         if (phase is GamePhase.Waiting || phase is GamePhase.Ended) return
 
-        val locKey = chest.location.toBlockKey()
+        val locKey = "${game.arena.name}:${chest.location.toBlockKey()}"
         if (filledChests.add(locKey)) {
             // Wasn't filled by chunk-load — fill now as fallback
             val tier = determineTier(chest, game)

--- a/src/main/kotlin/net/lumalyte/lumasg/listeners/ChestListener.kt
+++ b/src/main/kotlin/net/lumalyte/lumasg/listeners/ChestListener.kt
@@ -167,7 +167,10 @@ class ChestListener(
         Bukkit.getScheduler().runTaskLater(plugin, Runnable {
             val phase = game.phase
             if (phase is GamePhase.Active || phase is GamePhase.Deathmatch) {
-                filledChests.clear()
+                // Only reset this arena's fill tracking — a shared-world arena's refill
+                // must not wipe another arena's state (keeps H13 isolation intact).
+                val prefix = "${game.arena.name}:"
+                filledChests.removeIf { it.startsWith(prefix) }
                 game.broadcastRefillMessage()
             }
         }, config.chest.refillTimeSeconds * 20L)

--- a/src/main/kotlin/net/lumalyte/lumasg/service/ArenaService.kt
+++ b/src/main/kotlin/net/lumalyte/lumasg/service/ArenaService.kt
@@ -8,6 +8,7 @@ import net.lumalyte.lumasg.domain.Arena
 import net.lumalyte.lumasg.domain.SerializableLocation
 import net.lumalyte.lumasg.persistence.repositories.ArenaRepository
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.bukkit.Location
 import org.bukkit.entity.Player
@@ -24,6 +25,10 @@ class ArenaService(
     private val logger = LoggerFactory.getLogger(ArenaService::class.java)
     private val cache = ConcurrentHashMap<String, Arena>()
     private val selectedArenas = ConcurrentHashMap<UUID, String>()
+
+    private companion object {
+        const val MAX_PERSIST_ATTEMPTS = 3
+    }
 
     @PostConstruct
     suspend fun loadAll() {
@@ -63,8 +68,19 @@ class ArenaService(
     fun addToCache(arena: Arena) {
         cache[arena.name.lowercase()] = arena
         scope.launch {
-            runCatching { arenaRepo.save(arena) }
-                .onFailure { logger.warn("Failed to persist arena '${arena.name}' from addToCache", it) }
+            // Retry transient DB failures with exponential backoff so a brief blip doesn't
+            // silently drop the edit (the cache is already updated above for immediate use).
+            var lastError: Throwable? = null
+            for (attempt in 1..MAX_PERSIST_ATTEMPTS) {
+                val result = runCatching { arenaRepo.save(arena) }
+                if (result.isSuccess) { lastError = null; break }
+                lastError = result.exceptionOrNull()
+                logger.warn("Persist attempt $attempt/$MAX_PERSIST_ATTEMPTS failed for arena '${arena.name}'", lastError)
+                if (attempt < MAX_PERSIST_ATTEMPTS) delay(100L * (1L shl (attempt - 1)))
+            }
+            if (lastError != null) {
+                logger.error("Gave up persisting arena '${arena.name}' after $MAX_PERSIST_ATTEMPTS attempts; edit lives only in cache", lastError)
+            }
         }
     }
 

--- a/src/main/kotlin/net/lumalyte/lumasg/service/ArenaService.kt
+++ b/src/main/kotlin/net/lumalyte/lumasg/service/ArenaService.kt
@@ -7,6 +7,8 @@ import net.lumalyte.lumasg.config.LumaSGConfig
 import net.lumalyte.lumasg.domain.Arena
 import net.lumalyte.lumasg.domain.SerializableLocation
 import net.lumalyte.lumasg.persistence.repositories.ArenaRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.bukkit.Location
 import org.bukkit.entity.Player
 import org.slf4j.LoggerFactory
@@ -16,7 +18,8 @@ import java.util.concurrent.ConcurrentHashMap
 @Service
 class ArenaService(
     private val arenaRepo: ArenaRepository,
-    private val config: LumaSGConfig
+    private val config: LumaSGConfig,
+    private val scope: CoroutineScope
 ) {
     private val logger = LoggerFactory.getLogger(ArenaService::class.java)
     private val cache = ConcurrentHashMap<String, Arena>()
@@ -50,8 +53,19 @@ class ArenaService(
         cache.values.forEach { arenaRepo.save(it) }
     }
 
+    /**
+     * Update the in-memory arena and persist it asynchronously.
+     *
+     * Callers are synchronous Bukkit event handlers (e.g. the admin wand), so the DB write
+     * is fire-and-forget on the service scope rather than a suspend call. Without the
+     * persist, wand edits survived only until the next reload/crash (H12).
+     */
     fun addToCache(arena: Arena) {
         cache[arena.name.lowercase()] = arena
+        scope.launch {
+            runCatching { arenaRepo.save(arena) }
+                .onFailure { logger.warn("Failed to persist arena '${arena.name}' from addToCache", it) }
+        }
     }
 
     suspend fun removeArena(arena: Arena) {

--- a/src/test/kotlin/net/lumalyte/lumasg/domain/ArenaScanTest.kt
+++ b/src/test/kotlin/net/lumalyte/lumasg/domain/ArenaScanTest.kt
@@ -1,0 +1,25 @@
+package net.lumalyte.lumasg.domain
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ArenaScanTest {
+
+    @Test
+    fun `default radius 500 is rejected as unsafe`() {
+        assertFalse(Arena.isChestScanRadiusSafe(500.0))
+    }
+
+    @Test
+    fun `a sane arena-local radius is safe`() {
+        assertTrue(Arena.isChestScanRadiusSafe(32.0))
+        assertTrue(Arena.isChestScanRadiusSafe(Arena.MAX_CHEST_SCAN_RADIUS.toDouble()))
+    }
+
+    @Test
+    fun `zero or negative radius is rejected`() {
+        assertFalse(Arena.isChestScanRadiusSafe(0.0))
+        assertFalse(Arena.isChestScanRadiusSafe(-5.0))
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lumasg/service/ArenaServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lumasg/service/ArenaServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import net.lumalyte.lumasg.config.LumaSGConfig
 import net.lumalyte.lumasg.domain.Arena
@@ -48,6 +49,7 @@ class ArenaServiceTest {
 
         val a = arena("bravo")
         service.addToCache(a)
+        advanceUntilIdle() // let the retry/backoff loop run to exhaustion
 
         // Cache update is synchronous and must survive a failed async persist (H12 contract).
         assertEquals(a, service.getArena("bravo"))

--- a/src/test/kotlin/net/lumalyte/lumasg/service/ArenaServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lumasg/service/ArenaServiceTest.kt
@@ -1,0 +1,40 @@
+package net.lumalyte.lumasg.service
+
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.lumalyte.lumasg.config.LumaSGConfig
+import net.lumalyte.lumasg.domain.Arena
+import net.lumalyte.lumasg.domain.SerializableLocation
+import net.lumalyte.lumasg.persistence.repositories.ArenaRepository
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class ArenaServiceTest {
+
+    private fun arena(name: String) = Arena(
+        name = name,
+        displayName = name,
+        worldName = "world",
+        minPlayers = 2,
+        maxPlayers = 24,
+        spawnPoints = emptyList(),
+        center = SerializableLocation("world", 0.0, 64.0, 0.0)
+    )
+
+    @Test
+    fun `addToCache caches and persists the arena`() = runTest {
+        val repo = mockk<ArenaRepository>(relaxed = true)
+        val config = mockk<LumaSGConfig>(relaxed = true)
+        // UnconfinedTestDispatcher runs the launched persist eagerly, so coVerify sees it.
+        val service = ArenaService(repo, config, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        val a = arena("alpha")
+        service.addToCache(a)
+
+        assertEquals(a, service.getArena("alpha"))
+        coVerify(exactly = 1) { repo.save(a) }
+    }
+}

--- a/src/test/kotlin/net/lumalyte/lumasg/service/ArenaServiceTest.kt
+++ b/src/test/kotlin/net/lumalyte/lumasg/service/ArenaServiceTest.kt
@@ -1,5 +1,6 @@
 package net.lumalyte.lumasg.service
 
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
@@ -36,5 +37,21 @@ class ArenaServiceTest {
 
         assertEquals(a, service.getArena("alpha"))
         coVerify(exactly = 1) { repo.save(a) }
+    }
+
+    @Test
+    fun `addToCache keeps the arena cached even when every persist attempt fails`() = runTest {
+        val repo = mockk<ArenaRepository>(relaxed = true)
+        coEvery { repo.save(any()) } throws RuntimeException("DB unavailable")
+        val config = mockk<LumaSGConfig>(relaxed = true)
+        val service = ArenaService(repo, config, CoroutineScope(UnconfinedTestDispatcher(testScheduler)))
+
+        val a = arena("bravo")
+        service.addToCache(a)
+
+        // Cache update is synchronous and must survive a failed async persist (H12 contract).
+        assertEquals(a, service.getArena("bravo"))
+        // All retry attempts were made before giving up.
+        coVerify(exactly = 3) { repo.save(a) }
     }
 }


### PR DESCRIPTION
Remediation batch D of the [mass audit](https://github.com/BadgersMC/LumaSG/pull/5) — the final batch (1 crit + 2 high). Gate green; 2 new tests pass, no failures.

- **C2** `Arena.scanForChests()` was an uncapped cubic scan — ~10⁹ `getBlockAt` calls at the default radius 500, freezing the main thread for minutes, triggerable by anyone with setup permission. The radius is now capped at 64 (`MAX_CHEST_SCAN_RADIUS`) via a new `isChestScanRadiusSafe` helper, with a WARN log when an arena exceeds it. *(test: `ArenaScanTest`)*
- **H12** Admin-wand arena edits went through `ArenaService.addToCache` (in-memory only) and survived only until the next reload/crash. `addToCache` now also fire-and-forgets a DB persist on the service scope, so all callers — including the wand — persist with no call-site change. *(test: `ArenaServiceTest`, mockk `coVerify`)*

  Note: this required adding a `CoroutineScope` constructor param to `ArenaService` (Nexus injects it, same as `PlayerDataCache`'s scope) — the service had none.
- **H13** When two arenas share a world, chunk-load chest fill used the *first* matching game for every chest, filling arena B's chests with arena A's loot tier, and `filledChests` tracking was shared. Fill now resolves the owning game per chest by arena bounds (`distanceSquared <= radius²`) and keys `filledChests` by `arena:block`, keeping games isolated.

Files: `Arena.kt`, `ArenaService.kt`, `ChestListener.kt` (+ `ArenaScanTest`, `ArenaServiceTest`). Disjoint from batches A/B/C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
**Breaking**
- Require callers to supply a CoroutineScope to ArenaService (constructor signature changed)
- Migrate ChestListener filled-chest keys to arena-qualified "arenaName:blockKey" (persisted key format changed)

**Fixes**
- Clamp Arena.scanForChests() radius to MAX_CHEST_SCAN_RADIUS (64) to prevent uncapped cubic scans and main-thread freezes
- Persist ArenaService.addToCache() asynchronously on the injected CoroutineScope with retry/backoff so wand/admin edits survive reloads/crashes
- Resolve the owning arena per chest (bounds check) in ChestListener to prevent cross-arena loot mixing when multiple arenas share a world

**Features**
- Add Arena.MAX_CHEST_SCAN_RADIUS constant and Arena.isChestScanRadiusSafe(radius) helper
- Key filled-chests by "arenaName:blockKey" and clear refill state per-arena to isolate refill tracking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->